### PR TITLE
Input コンポーネント 作成

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { forwardRef } from "react";
+import styles from "./styles.module.css";
+import type { InputProps } from "./type";
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, size = "medium", className, ...props }, ref) => {
+    return (
+      <div className={styles.wrapper}>
+        {label && <label className={styles.label}>{label}</label>}
+        <input
+          ref={ref}
+          className={`${styles.input} ${styles[size]} ${error ? styles.error : ""} ${className || ""}`}
+          {...props}
+        />
+        {error && <span className={styles.errorMessage}>{error}</span>}
+      </div>
+    );
+  },
+);
+
+Input.displayName = "Input";
+
+export default Input;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import styles from "./styles.module.css";
 import type { InputProps } from "./type";
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,25 +1,16 @@
 "use client";
 
-import { forwardRef } from "react";
 import styles from "./styles.module.css";
 import type { InputProps } from "./type";
 
-const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, size = "medium", className, ...props }, ref) => {
-    return (
-      <div className={styles.wrapper}>
-        {label && <label className={styles.label}>{label}</label>}
-        <input
-          ref={ref}
-          className={`${styles.input} ${styles[size]} ${error ? styles.error : ""} ${className || ""}`}
-          {...props}
-        />
-        {error && <span className={styles.errorMessage}>{error}</span>}
-      </div>
-    );
-  },
-);
-
-Input.displayName = "Input";
+const Input = ({ label, error, size = "medium", ...props }: InputProps) => {
+  return (
+    <div className={styles.wrapper}>
+      {label && <label className={styles.label}>{label}</label>}
+      <input className={`${styles.input} ${styles[size]} ${error ? styles.error : ""}`} {...props} />
+      {error && <span className={styles.errorMessage}>{error}</span>}
+    </div>
+  );
+};
 
 export default Input;

--- a/src/components/Input/styles.module.css
+++ b/src/components/Input/styles.module.css
@@ -1,0 +1,69 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  font-family: "Geist", sans-serif;
+  color: #59636e;
+  display: block;
+}
+
+.input {
+  padding: 12px 16px;
+  border: 1px solid #ccc;
+  font-size: 12px;
+  font-weight: 400;
+  font-family: "Geist", sans-serif;
+  color: #59636e;
+  line-height: 100%;
+  transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input::placeholder {
+  color: #59636e;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 100%;
+  opacity: 1;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #0066ff;
+  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.1);
+}
+
+.input:disabled {
+  background-color: #f5f5f5;
+  cursor: not-allowed;
+  color: #999;
+}
+
+.medium {
+  height: 40px;
+  max-width: 480px;
+  border-radius: 8px;
+}
+
+.large {
+  height: 40px;
+  max-width: 720px;
+  border-radius: 5px;
+}
+
+.error {
+  border-color: #ff3333 !important;
+}
+
+.errorMessage {
+  font-size: 12px;
+  color: #ff3333;
+  display: block;
+}

--- a/src/components/Input/type.ts
+++ b/src/components/Input/type.ts
@@ -1,0 +1,7 @@
+import { InputHTMLAttributes } from "react";
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  label?: string;
+  error?: string;
+  size?: "medium" | "large";
+}


### PR DESCRIPTION
## 概要（何をしたPRか）

Input コンポーネントを実装しました。

## 関連Issue

Closes #7


## 変更内容

- Input コンポーネント実装（src/components/Input/）
  - `type.ts`: Props 型定義
  - `index.tsx`: forwardRef で実装
  - `styles.module.css`: Figma 仕様に準拠

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. ブランチをチェックアウト
2. Input コンポーネントを任意のページでインポート
3. label, error, size の各 props で動作確認

## テストケース

- [x] ラベルが表示される
- [x] プレースホルダーが表示される
- [x] medium/large サイズ切り替え可能


## スクリーンショット（UI変更がある場合）

<img width="931" height="413" alt="image" src="https://github.com/user-attachments/assets/89e097d9-7599-48e1-861f-1f0b5d2df5fe" />



## レビューしてほしい部分や不安な部分

- forwardRef パターンの実装は正しいか
- CSS Module の書き方は問題ないか


## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）

## 使用例（ダミーデータ）

### 名前入力欄
```tsx
<Input 
  label="名前"
  placeholder="名前を入力"
  size="medium"
/>
```

### コメント欄
```tsx
<Input 
  label="コメント"
  placeholder="コメントを入力"
  size="large"
/>
```