### PR TITLE
Fe/feature/6 post card skeleton

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -4,8 +4,7 @@ import { ButtonProps } from "./type";
 const Button = ({
   label,
   type = "button",
-  onClick,
-  disabled = false,
+  disabled,
   variant = "primary",
   size = "medium",
   loading = false,
@@ -14,7 +13,6 @@ const Button = ({
   return (
     <button
       type={type}
-      onClick={onClick}
       disabled={disabled || loading}
       className={`${styles.button}  ${styles[variant]} ${styles[size]}`}
       {...rest}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -10,7 +10,7 @@ const Button = ({
   ...rest
 }: ButtonProps) => {
   return (
-    <button type={type} className={`${styles.button}  ${styles[variant]} ${styles[size]}`} {...rest}>
+    <button type={type} disabled={loading} className={`${styles.button}  ${styles[variant]} ${styles[size]}`} {...rest}>
       {loading ? "Loading..." : label}
     </button>
   );

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -4,19 +4,13 @@ import { ButtonProps } from "./type";
 const Button = ({
   label,
   type = "button",
-  disabled,
   variant = "primary",
   size = "medium",
   loading = false,
   ...rest
 }: ButtonProps) => {
   return (
-    <button
-      type={type}
-      disabled={disabled || loading}
-      className={`${styles.button}  ${styles[variant]} ${styles[size]}`}
-      {...rest}
-    >
+    <button type={type} className={`${styles.button}  ${styles[variant]} ${styles[size]}`} {...rest}>
       {loading ? "Loading..." : label}
     </button>
   );

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import styles from "./styles.module.css";
 import { ButtonProps } from "./type";
 

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import styles from "./styles.module.css";
+import { ButtonProps } from "./type";
+
+const Button = ({
+  label,
+  type = "button",
+  onClick,
+  disabled = false,
+  variant = "primary",
+  size = "medium",
+  loading = false,
+  ...rest
+}: ButtonProps) => {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled || loading}
+      className={`${styles.button}  ${styles[variant]} ${styles[size]}`}
+      {...rest}
+    >
+      {loading ? "Loading..." : label}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button/styles.module.css
+++ b/src/components/Button/styles.module.css
@@ -1,0 +1,76 @@
+/* ベース */
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  font-weight: 700;
+  transition: filter 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  filter: brightness(0.85);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* variant */
+.primary {
+  background: rgba(56, 56, 56, 1);
+  color: rgba(255, 255, 255, 1);
+  border: 1px solid rgba(56, 56, 56, 1);
+  border-radius: 8px;
+  font-family: "Geist", sans-serif;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 1);
+  color: rgba(0, 0, 0, 1);
+  border: 1px solid rgba(0, 0, 0, 1);
+  border-radius: 8px;
+  font-family: "Geist", sans-serif;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.success {
+  background: rgba(24, 160, 251, 1);
+  color: rgba(255, 255, 255, 1);
+  border-radius: 6px;
+  font-family: "Montserrat", sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1;
+}
+
+.danger {
+  background: rgba(255, 65, 54, 1);
+  color: rgba(255, 255, 255, 1);
+  border-radius: 6px;
+  font-family: "Montserrat", sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1;
+}
+
+/* size */
+.medium {
+  width: 120px;
+  height: 40px;
+}
+
+.large {
+  width: 480px;
+  height: 48px;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}

--- a/src/components/Button/type.ts
+++ b/src/components/Button/type.ts
@@ -1,0 +1,11 @@
+import { ButtonHTMLAttributes } from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "success" | "danger";
+export type ButtonSize = "medium" | "large";
+
+export type ButtonProps = {
+  label: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+} & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/components/PostCardSkeleton/index.tsx
+++ b/src/components/PostCardSkeleton/index.tsx
@@ -1,0 +1,20 @@
+import styles from "./styles.module.css";
+
+export const PostCardSkeleton = () => {
+  return (
+    <div className={styles.postCard}>
+      <div className={styles.thumbnail} />
+      <div className={styles.container}>
+        <div className={styles.headerRow}>
+          <div className={styles.title} />
+          <div className={styles.category} />
+        </div>
+        <div className={styles.author} />
+        <div className={styles.content} />
+        <div className={styles.footerRow}>
+          <div className={styles.timestamp} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/PostCardSkeleton/styles.module.css
+++ b/src/components/PostCardSkeleton/styles.module.css
@@ -1,0 +1,69 @@
+/* ベース */
+.postCard {
+  width: 280px;
+  height: 324px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.thumbnail {
+  width: 100%;
+  height: 180px;
+  background: rgba(224, 231, 236, 1);
+}
+
+.container {
+  padding: 11px 11px 3px;
+}
+
+.title {
+  width: 73px;
+  height: 16px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+  flex: 1;
+}
+
+.headerRow {
+  height: 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.category {
+  width: 36px;
+  height: 16px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+}
+
+.author {
+  width: 27px;
+  height: 10px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.content {
+  width: 256px;
+  height: 36px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+  margin-top: 8px;
+}
+
+.footerRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.timestamp {
+  width: 40px;
+  height: 10px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+}


### PR DESCRIPTION
## 概要（何をしたPRか）
PostCardSkeletonコンポーネントを作成した

## 関連Issue

Closes #6

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

- PostCardSkeletonコンポーネントを作成（index.tsx / styles.module.css / type.ts）

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法
```tsx
<PostCardSkeleton />
```

## テストケース
- [x] PostCardと同じサイズで表示される
- [x] サムネイル・タイトル・カテゴリ・著者・本文・タイムスタンプがグレーのバーで表示される

## スクリーンショット（UI変更がある場合）
<img width="509" height="564" alt="image" src="https://github.com/user-attachments/assets/05d5a50a-e55c-46c3-bed4-5d24643f56ef" />

## レビューしてほしい部分や不安な部分

- PostCardをベースにテキストや画像をグレーのバーに置き換える実装にしました。
- type.tsはPropsが不要なため空ファイルにしています。削除すべきか確認お願いします。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
