### PR TITLE
Fe/feature/signup

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Input from "@/components/Input";
+import Link from "next/link";
+import styles from "./styles.module.css";
+
+export default function SignupPage() {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>新規登録</h1>
+
+      <form className={styles.form}>
+        <Input label="名前" type="text" placeholder="名前を入力" />
+
+        <Input label="メールアドレス" type="email" placeholder="メールアドレスを入力" />
+
+        <Input label="パスワード" type="password" placeholder="パスワードを入力" />
+
+        <button type="submit" className={styles.button}>
+          登録する
+        </button>
+      </form>
+
+      <div className={styles.loginLink}>
+        <span>すでにアカウントをお持ちの方は</span>
+        <Link href="/login">ログイン</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/styles.module.css
+++ b/src/app/signup/styles.module.css
@@ -1,0 +1,64 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 20px;
+  background-color: #f9f9f9;
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 40px;
+  color: #333;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  max-width: 480px;
+  margin-bottom: 20px;
+}
+
+.button {
+  padding: 12px 16px;
+  height: 40px;
+  background-color: #0066ff;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  margin-top: 8px;
+}
+
+.button:hover {
+  background-color: #0052cc;
+}
+
+.button:active {
+  background-color: #0047b2;
+}
+
+.loginLink {
+  font-size: 14px;
+  color: #59636e;
+  text-align: center;
+}
+
+.loginLink a {
+  color: #0066ff;
+  text-decoration: none;
+  font-weight: 600;
+  margin-left: 4px;
+}
+
+.loginLink a:hover {
+  text-decoration: underline;
+}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { forwardRef } from "react";
+import styles from "./styles.module.css";
+import type { InputProps } from "./type";
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, size = "medium", className, ...props }, ref) => {
+    return (
+      <div className={styles.wrapper}>
+        {label && <label className={styles.label}>{label}</label>}
+        <input
+          ref={ref}
+          className={`${styles.input} ${styles[size]} ${error ? styles.error : ""} ${className || ""}`}
+          {...props}
+        />
+        {error && <span className={styles.errorMessage}>{error}</span>}
+      </div>
+    );
+  },
+);
+
+Input.displayName = "Input";
+
+export default Input;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import styles from "./styles.module.css";
 import type { InputProps } from "./type";
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,25 +1,16 @@
 "use client";
 
-import { forwardRef } from "react";
 import styles from "./styles.module.css";
 import type { InputProps } from "./type";
 
-const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, size = "medium", className, ...props }, ref) => {
-    return (
-      <div className={styles.wrapper}>
-        {label && <label className={styles.label}>{label}</label>}
-        <input
-          ref={ref}
-          className={`${styles.input} ${styles[size]} ${error ? styles.error : ""} ${className || ""}`}
-          {...props}
-        />
-        {error && <span className={styles.errorMessage}>{error}</span>}
-      </div>
-    );
-  },
-);
-
-Input.displayName = "Input";
+const Input = ({ label, error, size = "medium", ...props }: InputProps) => {
+  return (
+    <div className={styles.wrapper}>
+      {label && <label className={styles.label}>{label}</label>}
+      <input className={`${styles.input} ${styles[size]} ${error ? styles.error : ""}`} {...props} />
+      {error && <span className={styles.errorMessage}>{error}</span>}
+    </div>
+  );
+};
 
 export default Input;

--- a/src/components/Input/styles.module.css
+++ b/src/components/Input/styles.module.css
@@ -1,0 +1,69 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 600;
+  font-family: "Geist", sans-serif;
+  color: #59636e;
+  display: block;
+}
+
+.input {
+  padding: 12px 16px;
+  border: 1px solid #ccc;
+  font-size: 12px;
+  font-weight: 400;
+  font-family: "Geist", sans-serif;
+  color: #59636e;
+  line-height: 100%;
+  transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input::placeholder {
+  color: #59636e;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 100%;
+  opacity: 1;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #0066ff;
+  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.1);
+}
+
+.input:disabled {
+  background-color: #f5f5f5;
+  cursor: not-allowed;
+  color: #999;
+}
+
+.medium {
+  height: 40px;
+  max-width: 480px;
+  border-radius: 8px;
+}
+
+.large {
+  height: 40px;
+  max-width: 720px;
+  border-radius: 5px;
+}
+
+.error {
+  border-color: #ff3333 !important;
+}
+
+.errorMessage {
+  font-size: 12px;
+  color: #ff3333;
+  display: block;
+}

--- a/src/components/Input/type.ts
+++ b/src/components/Input/type.ts
@@ -1,0 +1,7 @@
+import { InputHTMLAttributes } from "react";
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  label?: string;
+  error?: string;
+  size?: "medium" | "large";
+}


### PR DESCRIPTION
## 概要（何をしたPRか）

ワイヤーフレームを元にサインアップ画面を実装しました。

## 関連Issue

Closes #18


## 変更内容

- サインアップ画面の基本レイアウト実装
- 名前、メールアドレス、パスワード入力欄（Input コンポーネント再利用）
- 登録ボタン、ログインへのリンク実装
- CSS スタイリング（styles.module.css）

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `npm run dev` を実行
2. ブラウザで `http://localhost:3000/signup` を開く
3. 下記を確認してください：
   - タイトル「新規登録」が表示されている
   - 名前、メール、パスワード入力欄が縦に並んでいる
   - 「登録する」ボタンが青色で表示されている
   - 下部に「ログイン」リンクが表示されている

## テストケース

- [x] ブラウザエラーが出ていない
- [x] 入力欄が表示されている
- [x] ボタンが表示されている
- [ ] ログインへのリンクが機能している
  - 理由：現在は「見た目だけ」の実装なので、リンク遷移は未実装


## スクリーンショット（UI変更がある場合）

<img width="806" height="587" alt="image" src="https://github.com/user-attachments/assets/1942abe6-3b50-4fae-8d32-dc2d53facf66" />


## レビューしてほしい部分や不安な部分

- 見た目だけの実装なので、今後 onChange や onSubmit を追加予定です
- Input コンポーネントの再利用方法で改善点があれば教えてください

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
