### PR TITLE
[FE]ログイン画面

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import LoginForm from "@/components/LoginForm";
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import LoginForm from "@/components/LoginForm";
 
 export default function LoginPage() {

--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import Button from "../Button";
+import styles from "./styles.module.css";
+import Input from "../Input";
+
+export default function LoginForm() {
+  return (
+    <form className={styles.form}>
+      <h2 className={styles.title}>ログイン</h2>
+
+      <div className={styles.emailField}>
+        <Input label="メールアドレス" type="email" name="email" placeholder="メールアドレスを入力" />
+      </div>
+
+      <div className={styles.passwordField}>
+        <Input label="パスワード" type="password" name="password" placeholder="パスワード" />
+      </div>
+
+      <div className={styles.buttonWrapper}>
+        <Button label="ログイン" variant="success" size="large" />
+      </div>
+
+      <p className={styles.helperText}>
+        アカウントをお持ちでない方は
+        <Link href="/signup" className={styles.signupLink}>
+          新規登録
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -16,16 +16,16 @@ export default function LoginForm() {
         <Input label="パスワード" type="password" name="password" placeholder="パスワード" />
       </div>
 
-      <div className={styles.buttonWrapper}>
+      <div>
         <Button label="ログイン" variant="success" size="large" />
-      </div>
 
-      <p className={styles.helperText}>
-        アカウントをお持ちでない方は
-        <Link href="/signup" className={styles.signupLink}>
-          新規登録
-        </Link>
-      </p>
+        <p className={styles.helperText}>
+          アカウントをお持ちでない方は
+          <Link href="/signup" className={styles.signupLink}>
+            新規登録
+          </Link>
+        </p>
+      </div>
     </form>
   );
 }

--- a/src/components/LoginForm/styles.module.css
+++ b/src/components/LoginForm/styles.module.css
@@ -1,42 +1,22 @@
 .form {
-  width: 792px;
-  height: 442px;
-  position: absolute;
-  top: 200px;
-  left: 324px;
-  border-radius: 20px;
+  display: grid;
+  justify-content: center;
+  gap: 48px;
   background-color: #ffffff;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 20px;
 }
 
 .title {
-  width: 128px;
-  height: 42px;
-  position: absolute;
-  left: 332px;
   font-family: Geist;
   font-weight: 600;
   font-size: 32px;
   line-height: 100%;
   text-align: center;
   color: #000000;
-}
-
-.emailField {
-  width: 480px;
-  height: 72px;
-  position: absolute;
-  top: 90px;
-  left: 156px;
-  border-radius: 8px;
-}
-
-.passwordField {
-  width: 480px;
-  height: 72px;
-  position: absolute;
-  top: 210px;
-  left: 156px;
-  border-radius: 8px;
 }
 
 .emailField label,
@@ -48,21 +28,10 @@
   color: #000000;
 }
 
-.buttonWrapper {
-  width: 480px;
-  height: 48px;
-  position: absolute;
-  top: 330px;
-  left: 156px;
-}
-
 .helperText {
-  width: 216px;
-  height: 16px;
-  position: absolute;
-  top: 394px;
-  left: 420px;
+  margin-top: 16px;
   font-family: Geist;
+  text-align: right;
   font-weight: 600;
   font-size: 12px;
   line-height: 100%;

--- a/src/components/LoginForm/styles.module.css
+++ b/src/components/LoginForm/styles.module.css
@@ -1,0 +1,77 @@
+.form {
+  width: 792px;
+  height: 442px;
+  position: absolute;
+  top: 200px;
+  left: 324px;
+  border-radius: 20px;
+  background-color: #ffffff;
+}
+
+.title {
+  width: 128px;
+  height: 42px;
+  position: absolute;
+  left: 332px;
+  font-family: Geist;
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 100%;
+  text-align: center;
+  color: #000000;
+}
+
+.emailField {
+  width: 480px;
+  height: 72px;
+  position: absolute;
+  top: 90px;
+  left: 156px;
+  border-radius: 8px;
+}
+
+.passwordField {
+  width: 480px;
+  height: 72px;
+  position: absolute;
+  top: 210px;
+  left: 156px;
+  border-radius: 8px;
+}
+
+.emailField label,
+.passwordField label {
+  font-family: Poppins;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 100%;
+  color: #000000;
+}
+
+.buttonWrapper {
+  width: 480px;
+  height: 48px;
+  position: absolute;
+  top: 330px;
+  left: 156px;
+}
+
+.helperText {
+  width: 216px;
+  height: 16px;
+  position: absolute;
+  top: 394px;
+  left: 420px;
+  font-family: Geist;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 100%;
+}
+
+.signupLink {
+  font-family: Geist;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 100%;
+  color: #18a0fb;
+}


### PR DESCRIPTION
## 概要（何をしたPRか）
ワイヤーフレームを元にログイン画面のUIを実装しました。（Header部分は除く）

<!-- 1〜2行でOK -->

## 関連Issue

Closes #19 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

- ログイン画面のUIを実装
- LoginFormコンポーネントを作成（src/components/LoginForm）
- Input・Buttonコンポーネントを利用してフォームを構築
- /loginページ（src/app/login/page.tsx）を作成し、LoginFormを表示

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `npm run dev`で起動する
2. http://localhost:3000/login にアクセスし、Figmaと照らし合わせてご確認ください。

## テストケース

- [ ] ログインができる
- [ ] バリデーションが発火する
- [ ] 正常系の確認ができる
- [ ] 異常系の確認ができる
- [ x] 「新規登録」をクリックした時に、正しいURL（/signup）に遷移しようとするか
- [ x] メール・パスワード欄に文字入力が可能か
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）

<img width="1099" height="787" alt="image" src="https://github.com/user-attachments/assets/47ed106f-426e-49d4-9342-0f3314a764f1" />

<!-- 貼る -->

## レビューしてほしい部分や不安な部分

- 新規登録リンクの文字色の指定がデザインに無かったため、ボタンと同じ色にしましたが問題ないでしょうか？
- position: absolute; を複数使用していますが、レイアウト的に問題ないかご確認いただきたいです。
- Inputコンポーネントのスタイルと差異がありましたが、上書きを避けるためlabel以外は調整していません。この対応で問題ないでしょうか？

---

## 確認事項

- [ x] 作業ブランチで `git pull origin main` を実行した
- [ x] コンフリクトがあればローカルで解決した（不明なら相談する）
