### PR TITLE
[FE]ヘッダー コンポーネント

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,6 @@
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
 }
 
 body {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,24 +6,24 @@ import Button from "../Button";
 import Link from "next/link";
 
 export const Header = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
 
   return (
     <header className={styles.header}>
       {isLoggedIn ? (
         <div className={styles.buttonWrapper}>
-          <Link href="/articles/new">
-            <Button label="新規作成" variant="secondary" />
+          <Link href="/articles/new" className={`${styles.button}  ${styles.secondaryButton} ${styles.mediumButton}`}>
+            新規作成
           </Link>
           <Button label="ログアウト" onClick={() => setIsLoggedIn(false)} />
         </div>
       ) : (
         <div className={styles.buttonWrapper}>
-          <Link href="/login">
-            <Button label="ログイン" variant="secondary" />
+          <Link href="/login" className={`${styles.button}  ${styles.secondaryButton} ${styles.mediumButton}`}>
+            ログイン
           </Link>
-          <Link href="/signup">
-            <Button label="新規登録" />
+          <Link href="/signup" className={`${styles.button}  ${styles.primaryButton} ${styles.mediumButton}`}>
+            新規登録
           </Link>
         </div>
       )}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./styles.module.css";
+import Button from "../Button";
+import Link from "next/link";
+
+export const Header = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  return (
+    <header className={styles.header}>
+      {isLoggedIn ? (
+        <div className={styles.buttonWrapper}>
+          <Link href="/articles/new">
+            <Button label="新規作成" variant="secondary" />
+          </Link>
+          <Button label="ログアウト" onClick={() => setIsLoggedIn(false)} />
+        </div>
+      ) : (
+        <div className={styles.buttonWrapper}>
+          <Link href="/login">
+            <Button label="ログイン" variant="secondary" />
+          </Link>
+          <Link href="/signup">
+            <Button label="新規登録" />
+          </Link>
+        </div>
+      )}
+    </header>
+  );
+};

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -1,0 +1,17 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: 72px;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  background-color: #d9d9d9;
+}
+
+.buttonWrapper {
+  display: flex;
+  align-items: center;
+  margin-right: 24px;
+  gap: 24px;
+}

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -1,3 +1,4 @@
+/* ヘッダー */
 .header {
   position: sticky;
   top: 0;
@@ -14,4 +15,53 @@
   align-items: center;
   margin-right: 24px;
   gap: 24px;
+}
+
+/* ボタン */
+
+/* ベース */
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  font-weight: 700;
+  transition: filter 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  filter: brightness(0.85);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* variant */
+.primaryButton {
+  background: rgba(56, 56, 56, 1);
+  color: rgba(255, 255, 255, 1);
+  border: 1px solid rgba(56, 56, 56, 1);
+  border-radius: 8px;
+  font-family: "Geist", sans-serif;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.secondaryButton {
+  background: rgba(255, 255, 255, 1);
+  color: rgba(0, 0, 0, 1);
+  border: 1px solid rgba(0, 0, 0, 1);
+  border-radius: 8px;
+  font-family: "Geist", sans-serif;
+  font-size: 16px;
+  line-height: 1;
+}
+
+/* size */
+.mediumButton {
+  width: 120px;
+  height: 40px;
 }


### PR DESCRIPTION
## 概要（何をしたPRか）
Headerコンポーネントを作成

## 関連Issue

Closes #15

## 変更内容
```
src/
├── app/
│    └── globals.css (修正)
└── components/
     └── Header/
         ├── index.tsx (新規)
         └── styles.module.css (新規)
```


- `src/components/Header/index.tsx` : Headerコンポーネント（ログイン状態に応じてボタン表示を切替）
- `src/components/Header/styles.module.css` : Headerのスタイル定義（sticky配置、高さ72px）
- `src/app/globals.css` : `html, body` の `overflow-x: hidden` を削除（sticky 配置を有効にするため）

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `src/app/page.tsx` に以下のように `Header` を配置する
```tsx
import { Header } from "@/components/Header";

export default function Home() {
  return (
    <div>
      <Header />
    </div>
  );
}
```

2. `src/components/Header/index.tsx` の `useState(false)` を `useState(true)` に変更して配置する（ログイン時のスタイル・遷移確認）

```tsx
   import { Header } from "@/components/Header";

   export default function Home() {
     return (
       <div>
         <Header />
       </div>
     );
   }
```

3. `src/app/page.tsx` に以下のように `Header` と十分な高さのコンテンツを配置する（固定表示 sticky の確認）

```tsx
   import { Header } from "@/components/Header";

   export default function Home() {
     return (
       <div>
         <Header />
         <div style={{ height: "2000px" }}>スクロール用のコンテンツ</div>
       </div>
     );
   }
```

## テストケース


- [x] 正常系の確認ができる（Header が画面上部に固定表示される）
- [x] 未ログイン時に「ログイン」「新規登録」ボタンが表示され、各リンクに遷移できる
- [x] ログイン時に「新規作成」「ログアウト」ボタンが表示される
- [x] 「ログアウト」ボタン押下で未ログイン状態に切り替わる
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）
【未ログイン時】
<img width="1896" height="108" alt="image" src="https://github.com/user-attachments/assets/7f091e3f-990a-4291-af68-ea063cc1834f" />

【ログイン時】
<img width="1895" height="107" alt="image" src="https://github.com/user-attachments/assets/0652e880-a513-4cad-b482-339350880b9f" />

## レビューしてほしい部分や不安な部分
 - `<Link>` の中に `<Button>`（内部で `<button>` を描画）を入れているため、HTML的に `<a>` が `<button>` をラップする形になり不正な構造になっている可能性があるが、問題ないか。
 - ログイン状態を useState で管理しているが、将来的に認証機構（Context / Supabase Auth 等）に置き換える想定で問題ないか
 -  overflow-x: hidden を持つ祖先要素があると子孫の position: sticky が効かないため、Header を sticky 化するのに合わせてhtml, bodyのoverflow-x: hiddenを削除しているが、問題ないか。
---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
