### PR TITLE
[FE]カードスケルトンコンポーネント

### DIFF
--- a/src/components/PostCardSkeleton/index.tsx
+++ b/src/components/PostCardSkeleton/index.tsx
@@ -1,0 +1,20 @@
+import styles from "./styles.module.css";
+
+export const PostCardSkeleton = () => {
+  return (
+    <div className={styles.postCard}>
+      <div className={styles.thumbnail} />
+      <div className={styles.container}>
+        <div className={styles.headerRow}>
+          <div className={styles.title} />
+          <div className={styles.category} />
+        </div>
+        <div className={styles.author} />
+        <div className={styles.content} />
+        <div className={styles.footerRow}>
+          <div className={styles.timestamp} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/PostCardSkeleton/styles.module.css
+++ b/src/components/PostCardSkeleton/styles.module.css
@@ -1,0 +1,69 @@
+.postCard {
+  width: 280px;
+  height: 324px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.thumbnail {
+  width: 100%;
+  height: 180px;
+  background: rgba(224, 231, 236, 1);
+}
+
+.container {
+  padding: 11px 11px 3px;
+}
+
+.title {
+  width: 73px;
+  height: 16px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+  flex: 1;
+}
+
+.headerRow {
+  height: 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.category {
+  width: 36px;
+  height: 16px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+}
+
+.author {
+  width: 27px;
+  height: 10px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.content {
+  width: 256px;
+  height: 36px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+  margin-top: 8px;
+}
+
+.footerRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.timestamp {
+  width: 40px;
+  height: 10px;
+  background: rgba(224, 231, 236, 1);
+  border-radius: 4px;
+}


### PR DESCRIPTION
## 概要（何をしたPRか）

PostCardSkeletonコンポーネントを作成した

## 関連Issue

Closes #6

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

-PostCardSkeletonコンポーネントを作成（index.tsx / styles.module.css）

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法
```tsx
<PostCardSkeleton />
```

## テストケース

- [x] PostCardと同じサイズで表示される
- [x] サムネイル・タイトル・カテゴリ・著者・本文・タイムスタンプがグレーのバーで表示される
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）

<!-- 貼る -->
<img width="404" height="448" alt="image" src="https://github.com/user-attachments/assets/e5a813c3-b5d8-4458-be90-f1e287a3cc65" />


## レビューしてほしい部分や不安な部分

- プルリクのタイトルをissueのタイトルと揃えました。
- PostCardをベースにテキストや画像をグレーのバーに置き換える実装にしました。
- type.tsは削除しました。
- title と category 間に余白を作りました。（gap:8px;)
- ベースのコメントを削除しました。
---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）