### PR TITLE
[FE]検索フォームコンポーネント #34

### DIFF
--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./styles.module.css";
+import { SearchFormProps } from "./type";
+
+export const SearchForm = ({
+  onSearch,
+  placeholder = "検索したい記事を入力してください",
+  disabled = false,
+}: SearchFormProps) => {
+  const [keyword, setKeyword] = useState("");
+
+  const handleSearch = () => {
+    onSearch(keyword);
+  };
+
+  return (
+    <div className={styles.searchWrapper}>
+      <input
+        type="text"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        className={styles.searchInput}
+      />
+      <button onClick={handleSearch} disabled={disabled} className={styles.searchButton}>
+        検索
+      </button>
+    </div>
+  );
+};

--- a/src/components/SearchForm/styles.module.css
+++ b/src/components/SearchForm/styles.module.css
@@ -1,0 +1,47 @@
+.searchWrapper {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.searchInput {
+  width: 480px;
+  height: 40px;
+  border-radius: 8px;
+  border: 1px solid rgba(89, 99, 110, 1);
+  padding: 0 16px;
+  opacity: 0.5;
+  outline: none;
+  background: rgba(255, 255, 255, 1);
+}
+
+.searchButton {
+  width: 120px;
+  height: 40px;
+  background: rgba(56, 56, 56, 1);
+  color: rgba(255, 255, 255, 1);
+  border: none;
+  border-radius: 8px;
+  font-family: "Geist", sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1;
+  letter-spacing: 0%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.searchButton:hover:not(:disabled) {
+  filter: brightness(0.85);
+}
+
+.searchButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.searchInput:disabled {
+  cursor: not-allowed;
+}

--- a/src/components/SearchForm/type.ts
+++ b/src/components/SearchForm/type.ts
@@ -1,0 +1,5 @@
+export type SearchFormProps = {
+  onSearch: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+};


### PR DESCRIPTION
## 概要（何をしたPRか）
SearchFormコンポーネントを作成した

## 関連Issue

Closes #34 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

- SearchFormコンポーネントを作成（index.tsx / styles.module.css / type.ts）

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法
```tsx
<SearchForm onSearch={(value) => console.log(value)} />
```
## テストケース

- [x] 検索バーに文字が入力できる
- [x] 検索ボタン押下時にonSearchが発火する
- [x] disabled時に検索バー・ボタンが操作できない
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）

<img width="736" height="138" alt="image" src="https://github.com/user-attachments/assets/7626dbf5-a521-415c-b25e-4586937df8ec" />


## レビューしてほしい部分や不安な部分
- disabled：Buttonコンポーネントに合わせてグレーアウトで実装しました。（opacity: 0.5 / cursor: not-allowed）
- hover：Buttonコンポーネントに合わせてfilter: brightness(0.85)で実装しました。
  また、検索ボタンにcursor: pointerを追加しています。
- 検索バーのフォントサイズは仕様書に指定がなかったため、font-size: 14pxで実装しました。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
