### PR TITLE
[FE] 記事投稿画面

### DIFF
--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -16,7 +16,7 @@ export default function ArticleNewPage() {
         </div>
 
         <div className={styles.imageUpload}>
-          <span>後ほど画像アップロードコンポーネントを挿入する</span>
+          <span>画像プレビューコンポーネントのレビュー中のため、後ほど挿入する。</span>
         </div>
 
         <SelectBox

--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -7,16 +7,16 @@ import TextBox from "@/components/TextBox";
 
 export default function ArticleNewPage() {
   return (
-    <div className={styles.wrapper}>
+    <div>
       <Header />
 
-      <main>
+      <main className={styles.wrapper}>
         <div className={styles.inputWrapper}>
           <Input type="text" name="title" placeholder="タイトルを入力" size="large" />
         </div>
 
         <div className={styles.imageUpload}>
-          <span>画像プレビューコンポーネントのレビュー中のため、後ほど挿入する。</span>
+          <span>画像プレビューコンポーネントのレビュー中のため、後ほど挿入。</span>
         </div>
 
         <SelectBox

--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -1,0 +1,34 @@
+import Button from "@/components/Button";
+import { Header } from "@/components/Header";
+import Input from "@/components/Input";
+import SelectBox from "@/components/SelectBox";
+import styles from "./styles.module.css";
+
+export default function ArticleNewPage() {
+  return (
+    <div className={styles.wrapper}>
+      <Header />
+
+      <main>
+        <div className={styles.inputWrapper}>
+          <Input type="text" name="title" placeholder="タイトルを入力" size="large" />
+        </div>
+
+        <div className={styles.imageUpload}>
+          <span>後ほど画像アップロードコンポーネントを挿入する</span>
+        </div>
+
+        <SelectBox
+          options={["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"]}
+          placeholder="選択してください"
+        />
+
+        <textarea placeholder="本文を入力してください" className={styles.textBox} />
+
+        <div className={styles.buttonWrapper}>
+          <Button label="投稿" variant="success" size="medium" />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -3,6 +3,7 @@ import { Header } from "@/components/Header";
 import Input from "@/components/Input";
 import SelectBox from "@/components/SelectBox";
 import styles from "./styles.module.css";
+import TextBox from "@/components/TextBox";
 
 export default function ArticleNewPage() {
   return (
@@ -23,7 +24,7 @@ export default function ArticleNewPage() {
           placeholder="選択してください"
         />
 
-        <textarea placeholder="本文を入力してください" className={styles.textBox} />
+        <TextBox />
 
         <div className={styles.buttonWrapper}>
           <Button label="投稿" variant="success" size="medium" />

--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import SelectBox from "@/components/SelectBox";
 import styles from "./styles.module.css";
 import TextBox from "@/components/TextBox";
+import ImageUploaderPreview from "@/components/ImageUploaderPreview";
 
 export default function ArticleNewPage() {
   return (
@@ -16,7 +17,7 @@ export default function ArticleNewPage() {
         </div>
 
         <div className={styles.imageUpload}>
-          <span>画像プレビューコンポーネントのレビュー中のため、後ほど挿入。</span>
+          <ImageUploaderPreview />
         </div>
 
         <SelectBox

--- a/src/app/articles/new/page.tsx
+++ b/src/app/articles/new/page.tsx
@@ -1,5 +1,4 @@
 import Button from "@/components/Button";
-import { Header } from "@/components/Header";
 import Input from "@/components/Input";
 import SelectBox from "@/components/SelectBox";
 import styles from "./styles.module.css";
@@ -9,8 +8,6 @@ import ImageUploaderPreview from "@/components/ImageUploaderPreview";
 export default function ArticleNewPage() {
   return (
     <div>
-      <Header />
-
       <main className={styles.wrapper}>
         <div className={styles.inputWrapper}>
           <Input type="text" name="title" placeholder="タイトルを入力" size="large" />

--- a/src/app/articles/new/styles.module.css
+++ b/src/app/articles/new/styles.module.css
@@ -1,16 +1,19 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  /* align-items: center; */
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .inputWrapper {
   margin-top: 48px;
 }
 
-/*  ↓ 画像プレビューコンポーネントのレビュー中とのことで仮でデザインを入れてます  */
+/*  ↓ 画像プレビューコンポーネントのレビュー中とのことで仮でデザインを入れてます。  */
 .imageUpload {
-  width: 720px;
+  width: 100%;
   height: 360px;
   margin-top: 40px;
   margin-bottom: 105px;

--- a/src/app/articles/new/styles.module.css
+++ b/src/app/articles/new/styles.module.css
@@ -8,6 +8,7 @@
   margin-top: 48px;
 }
 
+/*  ↓ 画像プレビューコンポーネントのレビュー中とのことで仮でデザインを入れてます  */
 .imageUpload {
   width: 720px;
   height: 360px;

--- a/src/app/articles/new/styles.module.css
+++ b/src/app/articles/new/styles.module.css
@@ -10,14 +10,9 @@
   margin-top: 48px;
 }
 
-/*  ↓ 画像プレビューコンポーネントのレビュー中とのことで仮でデザインを入れてます。  */
 .imageUpload {
-  width: 100%;
-  height: 360px;
   margin-top: 40px;
   margin-bottom: 105px;
-  border: 2px dashed #000000;
-  border-radius: 8px;
 }
 
 .buttonWrapper {

--- a/src/app/articles/new/styles.module.css
+++ b/src/app/articles/new/styles.module.css
@@ -1,7 +1,6 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  /* align-items: center; */
   max-width: 720px;
   width: 100%;
   margin: 0 auto;

--- a/src/app/articles/new/styles.module.css
+++ b/src/app/articles/new/styles.module.css
@@ -1,0 +1,37 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.inputWrapper {
+  margin-top: 48px;
+}
+
+.imageUpload {
+  width: 720px;
+  height: 360px;
+  margin-top: 40px;
+  margin-bottom: 105px;
+  border: 2px dashed #000000;
+  border-radius: 8px;
+}
+
+.textBox {
+  width: 720px;
+  height: 240px;
+  border: none;
+  background: #e3e3e3;
+  border-radius: 41px;
+  padding: 24px;
+}
+
+.textBox:focus {
+  outline: 2px solid #d0d0d0;
+}
+
+.buttonWrapper {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 32px;
+}

--- a/src/app/articles/new/styles.module.css
+++ b/src/app/articles/new/styles.module.css
@@ -17,19 +17,6 @@
   border-radius: 8px;
 }
 
-.textBox {
-  width: 720px;
-  height: 240px;
-  border: none;
-  background: #e3e3e3;
-  border-radius: 41px;
-  padding: 24px;
-}
-
-.textBox:focus {
-  outline: 2px solid #d0d0d0;
-}
-
 .buttonWrapper {
   display: flex;
   justify-content: flex-end;

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -1,8 +1,13 @@
 import styles from "./styles.module.css";
 import { TextBoxProps } from "./type";
 
-const TextBox = ({ placeholder = "本文を入力してください", className, ...props }: TextBoxProps) => {
-  return <textarea placeholder={placeholder} className={`${styles.textBox} ${className ?? ""}`} {...props} />;
+const TextBox = ({ placeholder = "本文を入力してください", error, ...props }: TextBoxProps) => {
+  return (
+    <div>
+      <textarea placeholder={placeholder} className={`${styles.textBox} ${error ? styles.error : ""}`} {...props} />
+      {error && <p className={styles.errorMessage}>{error}</p>}
+    </div>
+  );
 };
 
 export default TextBox;

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -4,7 +4,7 @@ import { TextBoxProps } from "./type";
 const TextBox = ({ placeholder = "本文を入力してください", error, ...props }: TextBoxProps) => {
   return (
     <div>
-      <textarea placeholder={placeholder} className={`${styles.textBox} ${error ? styles.error : ""}`} {...props} />
+      <textarea placeholder={placeholder} className={`${styles.textBox} ${error && styles.error}`} {...props} />
       {error && <p className={styles.errorMessage}>{error}</p>}
     </div>
   );

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -1,0 +1,8 @@
+import styles from "./styles.module.css";
+import { TextBoxProps } from "./type";
+
+const TextBox = ({ placeholder = "本文を入力してください", className, ...props }: TextBoxProps) => {
+  return <textarea placeholder={placeholder} className={`${styles.textBox} ${className ?? ""}`} {...props} />;
+};
+
+export default TextBox;

--- a/src/components/TextBox/styles.module.css
+++ b/src/components/TextBox/styles.module.css
@@ -5,6 +5,8 @@
   background: #e3e3e3;
   border-radius: 41px;
   padding: 24px;
+  letter-spacing: 0.05em;
+  line-height: 1.8;
 }
 
 .textBox:focus {

--- a/src/components/TextBox/styles.module.css
+++ b/src/components/TextBox/styles.module.css
@@ -10,7 +10,14 @@
 }
 
 .textBox:focus {
-  outline: 2px solid #d0d0d0;
+  outline: 2px solid #888888;
+  background-color: white;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.05);
+}
+
+.textBox:hover {
+  background-color: #ededed;
+  cursor: pointer;
 }
 
 .errorMessage {

--- a/src/components/TextBox/styles.module.css
+++ b/src/components/TextBox/styles.module.css
@@ -1,0 +1,12 @@
+.textBox {
+  width: 720px;
+  height: 240px;
+  border: none;
+  background: #e3e3e3;
+  border-radius: 41px;
+  padding: 24px;
+}
+
+.textBox:focus {
+  outline: 2px solid #d0d0d0;
+}

--- a/src/components/TextBox/styles.module.css
+++ b/src/components/TextBox/styles.module.css
@@ -12,3 +12,7 @@
 .textBox:focus {
   outline: 2px solid #d0d0d0;
 }
+
+.errorMessage {
+  color: #b91c1c;
+}

--- a/src/components/TextBox/type.ts
+++ b/src/components/TextBox/type.ts
@@ -2,5 +2,4 @@ import { TextareaHTMLAttributes } from "react";
 
 export type TextBoxProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   error?: string;
-  label?: string;
 };

--- a/src/components/TextBox/type.ts
+++ b/src/components/TextBox/type.ts
@@ -2,4 +2,5 @@ import { TextareaHTMLAttributes } from "react";
 
 export type TextBoxProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   error?: string;
+  label?: string;
 };

--- a/src/components/TextBox/type.ts
+++ b/src/components/TextBox/type.ts
@@ -1,0 +1,5 @@
+import { TextareaHTMLAttributes } from "react";
+
+export type TextBoxProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  error?: string;
+};


### PR DESCRIPTION
## 概要（何をしたPRか）
ワイヤーフレームを元に、記事投稿画面を作成した。

<!-- 1〜2行でOK -->

## 関連Issue

Closes #32 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

- 記事投稿画面（`src/app/articles/new`）に `page.tsx` と `styles.module.css` を作成
- テキスト入力部分を共通コンポーネント化するため、`src/components/TextBox` を作成し実装

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `npm run dev`を起動する
2. ブラウザで、`http://localhost:3000/articles/new`にアクセスする

## テストケース

- [ ] ログインができる
- [ ] バリデーションが発火する
- [ ] 正常系の確認ができる
- [ ] 異常系の確認ができる
- [x] 画面が崩れずに表示されること
- [x] TextBoxコンポーネントが表示されていること
- [x] レイアウトが画面幅1440pxでデザイン通りになっていること
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）
<img width="929" height="791" alt="スクリーンショット 2026-04-25 112726" src="https://github.com/user-attachments/assets/65fa355c-c8f8-4ce4-841a-6607e2e2d783" />

<!-- 貼る -->

## レビューしてほしい部分や不安な部分

- SelectBoxコンポーネントが `position` 指定されている影響で、画面幅1440pxではデザイン通り表示されるが、PCで開いたときに、ずれてしまっているので確認していただきたい。(slackで質問し確認中とのことで、確認がとれ次第修正します。)

- 文字入力箇所を TextBoxコンポーネントに実装したが、型定義と`<textarea />` の実装が適切かどうか確認していただきたいです。
---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
