### PR TITLE
[FE]記事詳細画面

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,0 +1,94 @@
+import Image from "next/image";
+import { Header } from "@/components/Header";
+import { CommentCard } from "@/components/CommentCard";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import styles from "./styles.module.css";
+
+const article = {
+  title: "Blog Title",
+  author: "Author",
+  authorAvatarUrl: "/default_user_icon.png",
+  thumbnailUrl: "/sample1.jpg",
+  category: "Category",
+  content:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+};
+
+const comments = [
+  {
+    id: 1,
+    userName: "ユーザー名",
+    userAvatarUrl: "/default_user_icon.png",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    userName: "ユーザー名",
+    userAvatarUrl: "/default_user_icon.png",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+    created_at: new Date().toISOString(),
+  },
+];
+
+export default function ArticleDetailPage() {
+  return (
+    <>
+      <Header />
+      <main className={styles.main}>
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h1 className={styles.title}>{article.title}</h1>
+            <div className={styles.authorWrapper}>
+              <span className={styles.authorLabel}>Author</span>
+              <Image
+                src={article.authorAvatarUrl}
+                alt={article.author}
+                width={32}
+                height={32}
+                className={styles.avatar}
+              />
+            </div>
+          </div>
+          <div className={styles.thumbnail}>
+            <Image
+              src={article.thumbnailUrl}
+              alt={article.title}
+              fill
+              sizes="720px"
+              className={styles.thumbnailImage}
+            />
+          </div>
+          <span className={styles.category}>{article.category}</span>
+          <p className={styles.content}>{article.content}</p>
+          <div className={styles.footer}>
+            <time className={styles.timestamp}>a min ago</time>
+            <Button label="編集" variant="success" size="medium" />
+          </div>
+        </div>
+
+        <section className={styles.commentSection}>
+          <h2 className={styles.commentCount}>{comments.length}件のコメント</h2>
+          <div className={styles.commentInputWrapper}>
+            <Input placeholder="コメントを入力" size="large" />
+            <Button label="コメント" variant="success" size="medium" />
+          </div>
+          <div className={styles.commentList}>
+            {comments.map((comment) => (
+              <CommentCard
+                key={comment.id}
+                userName={comment.userName}
+                userAvatarUrl={comment.userAvatarUrl}
+                content={comment.content}
+                created_at={comment.created_at}
+              />
+            ))}
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -4,6 +4,7 @@ import { CommentCard } from "@/components/CommentCard";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
 import styles from "./styles.module.css";
+import { dateConvert } from "@/utils/dateconvert";
 
 const article = {
   title: "Blog Title",
@@ -13,6 +14,7 @@ const article = {
   category: "Category",
   content:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+  created_at: new Date().toISOString(),
 };
 
 const comments = [
@@ -43,7 +45,7 @@ export default function ArticleDetailPage() {
           <div className={styles.cardHeader}>
             <h1 className={styles.title}>{article.title}</h1>
             <div className={styles.authorWrapper}>
-              <span className={styles.authorLabel}>Author</span>
+              <span className={styles.authorLabel}>{article.author}</span>
               <Image
                 src={article.authorAvatarUrl}
                 alt={article.author}
@@ -65,7 +67,7 @@ export default function ArticleDetailPage() {
           <span className={styles.category}>{article.category}</span>
           <p className={styles.content}>{article.content}</p>
           <div className={styles.footer}>
-            <time className={styles.timestamp}>a min ago</time>
+            <time className={styles.timestamp}>{dateConvert(article.created_at)}</time>
             <Button label="編集" variant="success" size="medium" />
           </div>
         </div>

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import { Header } from "@/components/Header";
 import { CommentCard } from "@/components/CommentCard";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
@@ -11,7 +10,6 @@ import Link from "next/link";
 export default function ArticleDetailPage() {
   return (
     <>
-      <Header />
       <main className={styles.main}>
         <div className={styles.card}>
           <div className={styles.cardHeader}>

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -5,36 +5,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import styles from "./styles.module.css";
 import { dateConvert } from "@/utils/dateconvert";
-
-const article = {
-  title: "Blog Title",
-  author: "Author",
-  authorAvatarUrl: "/default_user_icon.png",
-  thumbnailUrl: "/sample1.jpg",
-  category: "Category",
-  content:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
-  created_at: new Date().toISOString(),
-};
-
-const comments = [
-  {
-    id: 1,
-    userName: "ユーザー名",
-    userAvatarUrl: "/default_user_icon.png",
-    content:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
-    created_at: new Date().toISOString(),
-  },
-  {
-    id: 2,
-    userName: "ユーザー名",
-    userAvatarUrl: "/default_user_icon.png",
-    content:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
-    created_at: new Date().toISOString(),
-  },
-];
+import { dummyArticle as article, dummyComments as comments } from "@/dummy/articleDetail";
 
 export default function ArticleDetailPage() {
   return (

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -49,10 +49,10 @@ export default function ArticleDetailPage() {
 
         <section className={styles.commentSection}>
           <h2 className={styles.commentCount}>{comments.length}件のコメント</h2>
-          <div className={styles.commentInputWrapper}>
+          <form className={styles.commentInputWrapper}>
             <Input placeholder="コメントを入力" size="large" />
             <Button label="コメント" variant="success" size="medium" />
-          </div>
+          </form>
           <div className={styles.commentList}>
             {comments.map((comment) => (
               <CommentCard

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -6,6 +6,7 @@ import Button from "@/components/Button";
 import styles from "./styles.module.css";
 import { dateConvert } from "@/utils/dateconvert";
 import { dummyArticle as article, dummyComments as comments } from "@/dummy/articleDetail";
+import Link from "next/link";
 
 export default function ArticleDetailPage() {
   return (
@@ -39,7 +40,10 @@ export default function ArticleDetailPage() {
           <p className={styles.content}>{article.content}</p>
           <div className={styles.footer}>
             <time className={styles.timestamp}>{dateConvert(article.created_at)}</time>
-            <Button label="編集" variant="success" size="medium" />
+            {/* バックエンド実装時に article.id に変更 */}
+            <Link href={`/articles/1/edit`}>
+              <Button label="編集" variant="success" size="medium" />
+            </Link>
           </div>
         </div>
 

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -1,7 +1,6 @@
 .main {
   max-width: 720px;
   margin: 40px auto;
-  padding: 0 16px;
 }
 
 .card {

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -1,0 +1,110 @@
+.main {
+  max-width: 720px;
+  margin: 40px auto;
+  padding: 0 16px;
+}
+
+.card {
+  border: 1px solid #d1d9e0;
+  padding: 24px;
+  background: #ffffff;
+  margin-bottom: 32px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: bold;
+  margin: 0;
+  flex: 1;
+}
+
+.authorWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.authorLabel {
+  font-size: 12px;
+  font-family: "Geist", sans-serif;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.thumbnail {
+  position: relative;
+  width: 100%;
+  height: 320px;
+  margin-bottom: 16px;
+}
+
+.thumbnailImage {
+  object-fit: cover;
+}
+
+.category {
+  display: block;
+  text-align: right;
+  font-size: 12px;
+  color: #4a90e2;
+  margin-bottom: 16px;
+}
+
+.content {
+  font-size: 14px;
+  color: #333;
+  margin-bottom: 8px;
+  line-height: 1.6;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+  padding-top: 12px;
+}
+
+.timestamp {
+  font-size: 12px;
+  color: #aaa;
+}
+
+.commentSection {
+  margin-top: 32px;
+}
+
+.commentCount {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0 0 16px 0;
+}
+
+.commentInputWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.commentList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/src/dummy/articleDetail.ts
+++ b/src/dummy/articleDetail.ts
@@ -1,0 +1,31 @@
+//詳細画面のダミーデータです。バックエンド実装時に削除予定。
+
+export const dummyArticle = {
+  title: "Blog Title",
+  author: "Author",
+  authorAvatarUrl: "/default_user_icon.png",
+  thumbnailUrl: "/sample1.jpg",
+  category: "Category",
+  content:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+  created_at: new Date().toISOString(),
+};
+
+export const dummyComments = [
+  {
+    id: 1,
+    userName: "ユーザー名",
+    userAvatarUrl: "/default_user_icon.png",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    userName: "ユーザー名",
+    userAvatarUrl: "/default_user_icon.png",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ligula nibh, interdum non enim sit amet, iaculis aliquet nunc.",
+    created_at: new Date().toISOString(),
+  },
+];


### PR DESCRIPTION
## 概要（何をしたPRか）

Figmaのワイヤーフレームをもとに記事詳細画面を実装しました。

## 関連Issue

Closes #31


## 変更内容
- `src/app/articles/[id]/page.tsx` の新規作成
- `src/app/articles/[id]/styles.module.css` の新規作成
- 現在はダミーデータで表示確認しています（Supabase連携は今後のIssueで対応予定）

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

- npm run dev を実行
http://localhost:3000/articles/1 にアクセス

## テストケース

- [x] 記事タイトル・著者・サムネイル・カテゴリ・本文が表示される
- [x] コメント一覧が表示される
- [x] コメント入力欄とコメントボタンが表示される
- [x] 編集ボタンが表示される

## スクリーンショット（UI変更がある場合）

<img width="1435" height="777" alt="image" src="https://github.com/user-attachments/assets/b9049738-510e-461f-b36b-877348de5e95" />
<img width="1435" height="306" alt="image" src="https://github.com/user-attachments/assets/7f954c05-d598-4eb3-a8f4-26c5d28f6e30" />




## レビューしてほしい部分や不安な部分

- ダミーデータ（`article` / `comments`）をコンポーネント関数の外に定義していますが、この書き方で問題ないでしょうか。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
