### PR TITLE
[FE]記事編集画面

### DIFF
--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import Input from "@/components/Input";
 import styles from "./styles.module.css";
 import SelectBox from "@/components/SelectBox";
 import Button from "@/components/Button";
+import ImageUploaderPreview from "@/components/ImageUploaderPreview";
 
 export default function ArticleEditPage() {
   return (
@@ -12,8 +13,9 @@ export default function ArticleEditPage() {
         <div className={styles.titleField}>
           <Input placeholder="タイトルを入力" type="text" size="large" />
         </div>
-        {/* TODO: ImageUploaderPreview コンポーネント実装後に差し替え */}
-        <div className={styles.imageWrapper}>ImageUploaderPreview コンポーネント</div>
+        <div className={styles.imageUploaderWrapper}>
+          <ImageUploaderPreview />
+        </div>
         <div className={styles.selectWrapper}>
           <SelectBox
             label="カテゴリ"

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -16,7 +16,7 @@ export default function ArticleEditPage() {
         <div className={styles.imageUploaderWrapper}>
           <ImageUploaderPreview />
         </div>
-        <div className={styles.selectWrapper}>
+        <div className={styles.selectBoxWrapper}>
           <SelectBox
             label="カテゴリ"
             options={["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"]}

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -1,0 +1,34 @@
+import { Header } from "@/components/Header";
+import Input from "@/components/Input";
+import styles from "./styles.module.css";
+import SelectBox from "@/components/SelectBox";
+import Button from "@/components/Button";
+
+export default function ArticleEditPage() {
+  return (
+    <>
+      <Header />
+      <main className={styles.content}>
+        <div className={styles.titleField}>
+          <Input placeholder="タイトルを入力" type="text" size="large" />
+        </div>
+        {/* TODO: ImageUploaderPreview コンポーネント実装後に差し替え */}
+        <div className={styles.imageWrapper}>ImageUploaderPreview コンポーネント</div>
+        <div className={styles.selectWrapper}>
+          <SelectBox
+            label="カテゴリ"
+            options={["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"]}
+            placeholder="カテゴリ選択"
+          />
+        </div>
+        {/* TODO: TextBox コンポーネント実装後に差し替え */}
+        <textarea placeholder="本文を入力してください" className={styles.textBox} aria-label="本文" />
+
+        <div className={styles.buttonWrapper}>
+          <Button label="更新" variant="success" />
+          <Button label="削除" variant="danger" />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -1,4 +1,3 @@
-import { Header } from "@/components/Header";
 import Input from "@/components/Input";
 import styles from "./styles.module.css";
 import SelectBox from "@/components/SelectBox";
@@ -8,7 +7,6 @@ import ImageUploaderPreview from "@/components/ImageUploaderPreview";
 export default function ArticleEditPage() {
   return (
     <>
-      <Header />
       <main className={styles.content}>
         <div className={styles.titleField}>
           <Input placeholder="タイトルを入力" type="text" size="large" />

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import styles from "./styles.module.css";
 import SelectBox from "@/components/SelectBox";
 import Button from "@/components/Button";
 import ImageUploaderPreview from "@/components/ImageUploaderPreview";
+import TextBox from "@/components/TextBox";
 
 export default function ArticleEditPage() {
   return (
@@ -21,9 +22,9 @@ export default function ArticleEditPage() {
             placeholder="カテゴリ選択"
           />
         </div>
-        {/* TODO: TextBox コンポーネント実装後に差し替え */}
-        <textarea placeholder="本文を入力してください" className={styles.textBox} aria-label="本文" />
-
+        <div className={styles.textBoxWrapper}>
+          <TextBox />
+        </div>
         <div className={styles.buttonWrapper}>
           <Button label="更新" variant="success" />
           <Button label="削除" variant="danger" />

--- a/src/app/articles/[id]/edit/styles.module.css
+++ b/src/app/articles/[id]/edit/styles.module.css
@@ -16,20 +16,12 @@
   margin-bottom: 24px;
 }
 
-.selectWrapper {
+.selectBoxWrapper {
+  flex-direction: column;
   width: 100%;
   display: flex;
-  justify-content: flex-end;
+  align-items: flex-end;
   margin-bottom: 24px;
-}
-
-/* TODO: SelectBox の position:absolute 削除後に本ブロックは不要 */
-.selectWrapper > div {
-  position: static;
-  top: auto;
-  left: auto;
-  display: flex;
-  flex-direction: column;
 }
 
 .textBox {

--- a/src/app/articles/[id]/edit/styles.module.css
+++ b/src/app/articles/[id]/edit/styles.module.css
@@ -1,0 +1,61 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  padding-top: 48px;
+  margin: 0 auto;
+  align-items: center;
+  max-width: 720px;
+}
+
+.titleField {
+  width: 100%;
+  margin-bottom: 40px;
+}
+
+.imageWrapper {
+  width: 100%;
+  height: 360px;
+  margin-bottom: 24px;
+  border: 2px dashed #000000;
+  border-radius: 8px;
+}
+
+.selectWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 24px;
+}
+
+/* TODO: SelectBox の position:absolute 削除後に本ブロックは不要 */
+.selectWrapper > div {
+  position: static;
+  top: auto;
+  left: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.textBox {
+  width: 100%;
+  box-sizing: border-box;
+  height: 240px;
+  border: none;
+  background: #e3e3e3;
+  border-radius: 41px;
+  padding: 24px;
+  letter-spacing: 0.05em;
+  line-height: 1.8;
+  margin-bottom: 32px;
+}
+
+.textBox:focus {
+  outline: 2px solid #d0d0d0;
+}
+
+.buttonWrapper {
+  display: flex;
+  gap: 24px;
+  width: 100%;
+  justify-content: flex-end;
+}

--- a/src/app/articles/[id]/edit/styles.module.css
+++ b/src/app/articles/[id]/edit/styles.module.css
@@ -12,12 +12,8 @@
   margin-bottom: 40px;
 }
 
-.imageWrapper {
-  width: 100%;
-  height: 360px;
+.imageUploaderWrapper {
   margin-bottom: 24px;
-  border: 2px dashed #000000;
-  border-radius: 8px;
 }
 
 .selectWrapper {

--- a/src/app/articles/[id]/edit/styles.module.css
+++ b/src/app/articles/[id]/edit/styles.module.css
@@ -24,21 +24,8 @@
   margin-bottom: 24px;
 }
 
-.textBox {
-  width: 100%;
-  box-sizing: border-box;
-  height: 240px;
-  border: none;
-  background: #e3e3e3;
-  border-radius: 41px;
-  padding: 24px;
-  letter-spacing: 0.05em;
-  line-height: 1.8;
+.textBoxWrapper {
   margin-bottom: 32px;
-}
-
-.textBox:focus {
-  outline: 2px solid #d0d0d0;
 }
 
 .buttonWrapper {


### PR DESCRIPTION
## 概要（何をしたPRか）

記事編集画面を作成

## 関連Issue

Closes #33 

## 変更内容
```
src/
└── app/
     └── articles/
         └── [id]/
             └── edit/
                 ├── page.tsx (新規)
                 └── styles.module.css (新規)
```

* `src/app/articles/[id]/edit/page.tsx` : 記事編集ページ（タイトル / 画像 / カテゴリ / 本文の入力欄、更新・削除ボタン）
* `src/app/articles/[id]/edit/styles.module.css` : 記事編集ページのスタイル定義

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. 開発サーバーを起動する

```bash
npm run dev
```

2. ブラウザで `http://localhost:3000/articles/1/edit` にアクセスする（`[id]` 部分は任意の値で可）
3. 以下のレイアウトが表示されることを確認する
   - ヘッダー
   - タイトル入力欄
   - 画像アップロード領域（プレースホルダー）
   - カテゴリ選択
   - 本文入力欄（textarea）
   - 「更新」「削除」ボタン


## テストケース

- [x] 正常系の確認ができる（編集画面のレイアウトが崩れず表示される）
- [x] タイトル入力欄に文字が入力できる
- [x] カテゴリ選択で 8 種類（日常 / 仕事 / 勉強 / 美容 / 趣味 / 購入品 / 健康 / その他）から選択できる
- [x] 本文の textarea に文字が入力できる
- [x] 「更新」「削除」ボタンが表示される

## スクリーンショット（UI変更がある場合）
<img width="1915" height="1515" alt="image" src="https://github.com/user-attachments/assets/232e0d3a-bf39-49ed-81a0-ca66a1acc262" />

## レビューしてほしい部分や不安な部分
 -  `ImageUploaderPreview` / `TextBox` コンポーネントは未実装のため、暫定でプレースホルダー `<div>` および素の `<textarea>` を使用しています。実装完了後に差し替え予定（コードに TODO コメントを記載）。
 -  `SelectBox` コンポーネントの `.wrapper` に `position: absolute` が残っているため、本ページ側で `.selectWrapper > div { position: static; ... }` により暫定で上書きしています。
 -  `[id]` 動的ルートですが、本PRでは画面レイアウトの実装のみで、データ取得・フォーム送信処理は含んでいません。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
