### PR TITLE
[FE]ホーム画面 #30

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,5 @@
+"use server";
+
+export async function searchAction(formData: FormData) {
+  console.log(formData.get("keyword"));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Header } from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,7 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,107 @@
+"use client";
+
+import { Header } from "@/components/Header";
+import { PostCard } from "@/components/PostCard";
+import { SearchForm } from "@/components/SearchForm";
 import styles from "./styles.module.css";
+
+const dummyPosts = [
+  {
+    id: 1,
+    title: "1つ目の投稿",
+    author: "山田 太郎",
+    category: "Category",
+    thumbnailUrl: "/sample1.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 2,
+    title: "2つ目の投稿",
+    author: "鈴木 花子",
+    category: "Category",
+    thumbnailUrl: "/sample2.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 3,
+    title: "3つ目の投稿",
+    author: "高橋 健太",
+    category: "Category",
+    thumbnailUrl: "/sample3.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 4,
+    title: "4つ目の投稿",
+    author: "田中 美咲",
+    category: "Category",
+    thumbnailUrl: "/sample4.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 5,
+    title: "5つ目の投稿",
+    author: "伊藤 翔太",
+    category: "Category",
+    thumbnailUrl: "/sample5.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 6,
+    title: "6つ目の投稿",
+    author: "渡辺 彩",
+    category: "Category",
+    thumbnailUrl: "/sample1.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 7,
+    title: "7つ目の投稿",
+    author: "山本 大輔",
+    category: "Category",
+    thumbnailUrl: "/sample2.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+  {
+    id: 8,
+    title: "8つ目の投稿",
+    author: "中村 光",
+    category: "Category",
+    thumbnailUrl: "/sample3.jpg",
+    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
+    createdAt: new Date(),
+  },
+];
 
 export default function Home() {
   return (
-    <div>
-      <h1 className={styles.title}>Hello Teamdev!!</h1>
-    </div>
+    <>
+      <Header />
+      <main className={styles.main}>
+        <div className={styles.searchWrapper}>
+          <SearchForm onSearch={(value) => console.log(value)} />
+        </div>
+        <div className={styles.cardGrid}>
+          {dummyPosts.map((post) => (
+            <PostCard
+              key={post.id}
+              title={post.title}
+              author={post.author}
+              category={post.category}
+              thumbnailUrl={post.thumbnailUrl}
+              content={post.content}
+              createdAt={post.createdAt}
+            />
+          ))}
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Header } from "@/components/Header";
 import { PostCard } from "@/components/PostCard";
 import { SearchForm } from "@/components/SearchForm";
 import styles from "./styles.module.css";
@@ -83,7 +82,6 @@ const dummyPosts = [
 export default function Home() {
   return (
     <>
-      <Header />
       <main className={styles.main}>
         <div className={styles.searchWrapper}>
           <SearchForm onSearch={(value) => console.log(value)} />

--- a/src/app/styles.module.css
+++ b/src/app/styles.module.css
@@ -1,6 +1,18 @@
-.title {
-  height: 100vh;
+.main {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 40px 64px;
+}
+
+.searchWrapper {
   display: flex;
   justify-content: center;
-  align-items: center;
+  margin-bottom: 40px;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 280px);
+  gap: 46px 60px;
+  justify-content: center;
 }


### PR DESCRIPTION
## 概要（何をしたPRか）
Home画面のUIを実装

## 関連Issue

Closes #30

## 変更内容

- page.tsxにHeader・SearchForm・PostCardコンポーネントを組み合わせてHome画面を実装
- styles.module.cssにレイアウトのスタイルを追加

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1.ダミーデータで8枚のPostCardが表示される
2.SearchFormで検索キーワードを入力してボタンを押すとconsole.logに出力される

## テストケース

- [x] ヘッダーが表示される
- [x] 検索バーに文字が入力できる
- [x] PostCardが8枚表示される
- [x] ホバー時にPostCardが浮き出る

## スクリーンショット（UI変更がある場合）
<img width="2559" height="1230" alt="image" src="https://github.com/user-attachments/assets/dd1fdbcf-e567-4536-bc66-a2acaaceded3" />

## レビューしてほしい部分や不安な部分

- onSearchは現時点で検索処理が未実装のため、console.logで代替しています。
   Supabaseとの連携時に実際の処理に置き換え予定です。
- Figma上で余白を確認できなかった箇所は独自で指定しました。(padding: 40px 64px)
- cardGridのgapも同様です。（gap: 46px 60px）
---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
