### PR TITLE
[FIX]セレクトボックスコンポーネント

### DIFF
--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -3,7 +3,7 @@ import styles from "./styles.module.css";
 
 const SelectBox = ({ label, options, placeholder, ...selectProps }: SelectProps) => {
   return (
-    <div className={styles.wrapper}>
+    <>
       <label className={styles.label}>{label}</label>
       <select className={styles.select} {...selectProps}>
         <option value="">{placeholder}</option>
@@ -13,7 +13,7 @@ const SelectBox = ({ label, options, placeholder, ...selectProps }: SelectProps)
           </option>
         ))}
       </select>
-    </div>
+    </>
   );
 };
 

--- a/src/components/SelectBox/styles.module.css
+++ b/src/components/SelectBox/styles.module.css
@@ -1,9 +1,3 @@
-.wrapper {
-  position: absolute;
-  top: 584px;
-  left: 840px;
-}
-
 .label {
   width: 240px;
   height: 17px;


### PR DESCRIPTION
## 概要（何をしたPRか）

SelectBox コンポーネントから不要な position 指定を削除

## 関連Issue

Closes #42 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

```
src/
└── components/
    └── SelectBox/
        ├── index.tsx (修正)
        └── styles.module.css (修正)
```
 - src/components/SelectBox/styles.module.css : .wrapper の position: absolute / top / left を削除し、空ルールとなった .wrapper 自体も削除
 - src/components/SelectBox/index.tsx : 不要になった wrapper の <div> を React Fragment (<>) に置き換え

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

 src/app/page.tsx に以下のように SelectBoxを配置する
 ```
import SelectBox from "@/components/SelectBox";

export default function Home() {
  return <SelectBox label="カテゴリー" options={["A", "B", "C"]} placeholder="選択カテゴリー" />;
}
```

## テストケース

- [x] 正常系の確認ができる（SelectBox が利用箇所のレイアウト通りに表示される）
- [x] ラベルとセレクトボックスが縦並びで表示される
- [x] placeholder が初期表示される
- [x] options で渡した選択肢が一覧に表示され、選択できる

## スクリーンショット（UI変更がある場合）
コンポーネント自体の位置指定の削除のみのため、不要の判断。

## レビューしてほしい部分や不安な部分

- .wrapper の CSS ルールを完全削除し、JSX 側も <div> から React Fragment に変更しています。ラッパー要素が必要な利用ケースがあればご指摘ください。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
