### PR TITLE
[BE]サインアップ

### DIFF
--- a/src/app/signup/actions.ts
+++ b/src/app/signup/actions.ts
@@ -1,0 +1,158 @@
+"use server";
+
+import { createClient } from "@/libs/supabase/server";
+
+type SignupErrors = {
+  name?: string;
+  email?: string;
+  password?: string;
+  form?: string;
+};
+
+export type SignupFormState = {
+  errors: SignupErrors;
+  values: {
+    name: string;
+    email: string;
+  };
+  success: boolean;
+  message?: string;
+};
+
+type SignupFormValues = {
+  name: string;
+  email: string;
+  password: string;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const getValue = (formData: FormData, key: string) => {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+};
+
+const getSignupFormValues = (formData: FormData): SignupFormValues => {
+  return {
+    name: getValue(formData, "name"),
+    email: getValue(formData, "email"),
+    password: getValue(formData, "password"),
+  };
+};
+
+const validateSignupForm = (values: SignupFormValues) => {
+  const errors: SignupErrors = {};
+
+  if (!values.name) {
+    errors.name = "名前を入力してください";
+  } else if (values.name.length > 12) {
+    errors.name = "名前は12文字以内で入力してください";
+  }
+
+  if (!values.email) {
+    errors.email = "メールアドレスを入力してください";
+  } else if (!EMAIL_PATTERN.test(values.email)) {
+    errors.email = "メールアドレスの形式が正しくありません";
+  }
+
+  if (!values.password) {
+    errors.password = "パスワードを入力してください";
+  } else if (values.password.length < 8) {
+    errors.password = "パスワードは8文字以上で入力してください";
+  } else if (values.password.length > 24) {
+    errors.password = "パスワードは24文字以内で入力してください";
+  }
+
+  return errors;
+};
+
+const createErrorState = (values: SignupFormValues, errors: SignupErrors): SignupFormState => {
+  return {
+    errors,
+    values: {
+      name: values.name,
+      email: values.email,
+    },
+    success: false,
+  };
+};
+
+export async function signupAction(_: SignupFormState, formData: FormData): Promise<SignupFormState> {
+  const values = getSignupFormValues(formData);
+  const errors = validateSignupForm(values);
+
+  if (Object.keys(errors).length > 0) {
+    return createErrorState(values, errors);
+  }
+
+  const supabase = await createClient();
+
+  const { data: existingUser, error: existingUserError } = await supabase
+    .from("users")
+    .select("id")
+    .eq("email", values.email)
+    .maybeSingle();
+
+  if (existingUserError) {
+    return createErrorState(values, {
+      form: "登録済みメールアドレスの確認に失敗しました。時間をおいて再度お試しください",
+    });
+  }
+
+  if (existingUser) {
+    return createErrorState(values, {
+      email: "このメールアドレスは既に登録されています",
+    });
+  }
+
+  const { data: authData, error: authError } = await supabase.auth.signUp({
+    email: values.email,
+    password: values.password,
+    options: {
+      data: {
+        name: values.name,
+      },
+    },
+  });
+
+  if (authError) {
+    return createErrorState(values, {
+      form: "ユーザー登録に失敗しました。入力内容を確認してください",
+    });
+  }
+
+  if (!authData.user || authData.user.identities?.length === 0) {
+    return createErrorState(values, {
+      email: "このメールアドレスは既に登録されています",
+    });
+  }
+
+  const now = new Date().toISOString();
+  const { error: insertUserError } = await supabase.from("users").insert({
+    id: authData.user.id,
+    name: values.name,
+    email: values.email,
+    image_path: null,
+    created_at: now,
+    updated_at: now,
+  });
+
+  if (insertUserError) {
+    if (insertUserError.code === "23505") {
+      return createErrorState(values, {
+        email: "このメールアドレスは既に登録されています",
+      });
+    }
+
+    return createErrorState(values, {
+      form: "ユーザー情報の登録に失敗しました。時間をおいて再度お試しください",
+    });
+  }
+
+  return {
+    errors: {},
+    values: { name: "", email: "" },
+    success: true,
+    message: "登録が完了しました",
+  };
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,17 +1,63 @@
+"use client";
+
 import Input from "@/components/Input";
 import Link from "next/link";
 import styles from "./styles.module.css";
 import Button from "@/components/Button";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { signupAction, type SignupFormState } from "./actions";
+
+const initialState: SignupFormState = {
+  errors: {},
+  values: {
+    name: "",
+    email: "",
+  },
+  success: false,
+};
+
+const SubmitButton = () => {
+  const { pending } = useFormStatus();
+
+  return <Button label="登録する" type="submit" variant="success" size="large" loading={pending} />;
+};
 
 export default function SignupPage() {
+  const [state, formAction] = useActionState(signupAction, initialState);
+
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>新規登録</h1>
-      <form className={styles.form}>
-        <Input label="名前" type="text" placeholder="名前を入力" />
-        <Input label="メールアドレス" type="email" placeholder="メールアドレスを入力" />
-        <Input label="パスワード" type="password" placeholder="パスワードを入力" />
-        <Button label="登録する" type="submit" variant="success" size="large" />
+      <form action={formAction} className={styles.form} noValidate>
+        <Input
+          label="名前"
+          type="text"
+          name="name"
+          placeholder="名前を入力"
+          defaultValue={state.values.name}
+          error={state.errors.name}
+        />
+        <Input
+          label="メールアドレス"
+          type="email"
+          name="email"
+          placeholder="メールアドレスを入力"
+          defaultValue={state.values.email}
+          error={state.errors.email}
+        />
+        <Input
+          label="パスワード"
+          type="password"
+          name="password"
+          placeholder="パスワードを入力"
+          error={state.errors.password}
+        />
+
+        {state.errors.form && <p className={styles.errorMessage}>{state.errors.form}</p>}
+        {state.success && state.message && <p className={styles.successMessage}>{state.message}</p>}
+
+        <SubmitButton />
       </form>
 
       <div className={styles.loginLink}>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import styles from "./styles.module.css";
 import Button from "@/components/Button";
 import { useActionState } from "react";
-import { useFormStatus } from "react-dom";
 import { signupAction, type SignupFormState } from "./actions";
 
 const initialState: SignupFormState = {
@@ -17,14 +16,8 @@ const initialState: SignupFormState = {
   success: false,
 };
 
-const SubmitButton = () => {
-  const { pending } = useFormStatus();
-
-  return <Button label="登録する" type="submit" variant="success" size="large" loading={pending} />;
-};
-
 export default function SignupPage() {
-  const [state, formAction] = useActionState(signupAction, initialState);
+  const [state, formAction, isPending] = useActionState(signupAction, initialState);
 
   return (
     <div className={styles.container}>
@@ -57,7 +50,7 @@ export default function SignupPage() {
         {state.errors.form && <p className={styles.errorMessage}>{state.errors.form}</p>}
         {state.success && state.message && <p className={styles.successMessage}>{state.message}</p>}
 
-        <SubmitButton />
+        <Button label="登録する" type="submit" variant="success" size="large" loading={isPending} />
       </form>
 
       <div className={styles.loginLink}>

--- a/src/app/signup/styles.module.css
+++ b/src/app/signup/styles.module.css
@@ -7,6 +7,7 @@
   padding: 20px;
   background-color: #ffffff;
 }
+
 .title {
   font-size: 32px;
   font-weight: 700;
@@ -42,4 +43,20 @@
 
 .loginLink a:hover {
   text-decoration: underline;
+}
+
+.errorMessage,
+.successMessage {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: "Geist", sans-serif;
+}
+
+.errorMessage {
+  color: #ff3333;
+}
+
+.successMessage {
+  color: #008a2e;
 }


### PR DESCRIPTION
## 概要（何をしたPRか）
新規登録画面で、名前、メールアドレス、パスワードをSupabase AuthのUsersテーブルに登録されるようにした。
<!-- 1〜2行でOK -->

## 関連Issue

Closes #17 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

signupページの以下のファイルを変更
・actions.ts、page.tsx→フォームに入力した情報がSupabase Authに登録される処理追加
・styles.module.css→文字数エラー等のスタイル追加


## 影響範囲

- [x] UI
- [x] BE
- [x] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1.ダミーデータを用意し、実際に新規登録が可能かテスト
2.エラーメッセージの表示が正しいかテスト

## テストケース

- [x] 新規登録ができる
- [x] バリデーションが発火する
- [x] 正常系の確認ができる
- [x] 異常系の確認ができる
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）
<img width="866" height="772" alt="Screenshot 2026-04-28 224145" src="https://github.com/user-attachments/assets/00e9235a-2b53-4acf-8e5f-e8b08dd7c67b" />
<!-- 貼る -->

## レビューしてほしい部分や不安な部分

非同期処理の部分の記述が、これでよいのか不安です。


---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
