### PR TITLE
[FE]検索フォームコンポーネント #34

### DIFF
--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -3,31 +3,29 @@
 import { useState } from "react";
 import styles from "./styles.module.css";
 import { SearchFormProps } from "./type";
+import Button from "../Button";
 
 export const SearchForm = ({
-  onSearch,
+  searchAction,
   placeholder = "検索したい記事を入力してください",
   disabled = false,
 }: SearchFormProps) => {
   const [keyword, setKeyword] = useState("");
 
-  const handleSearch = () => {
-    onSearch(keyword);
-  };
-
   return (
-    <div className={styles.searchWrapper}>
-      <input
-        type="text"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        placeholder={placeholder}
-        disabled={disabled}
-        className={styles.searchInput}
-      />
-      <button onClick={handleSearch} disabled={disabled} className={styles.searchButton}>
-        検索
-      </button>
-    </div>
+    <form action={searchAction}>
+      <div className={styles.searchWrapper}>
+        <input
+          type="text"
+          name="keyword"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={styles.searchInput}
+        />
+        <Button label="検索" disabled={disabled} />
+      </div>
+    </form>
   );
 };

--- a/src/components/SearchForm/type.ts
+++ b/src/components/SearchForm/type.ts
@@ -1,5 +1,5 @@
 export type SearchFormProps = {
-  onSearch: (value: string) => void;
+  searchAction: (formData: FormData) => Promise<void>;
   placeholder?: string;
   disabled?: boolean;
 };


### PR DESCRIPTION
## 概要（何をしたPRか）
SearchFormコンポーネントをServer Actions対応に修正した

## 関連Issue
Closes #34 

## 変更内容
- onSearchをsearchActionに変更（Server Actions対応）
- buttonタグをButtonコンポーネントに変更
- divタグをformタグに変更

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法
```tsx
<SearchForm searchAction={handleSearch} />
```

<SearchForm searchAction={handleSearch} />
```

## テストケース
- [x] 検索バーに文字が入力できる
- [x] disabled時に検索バー・ボタンが操作できない

## スクリーンショット（UI変更がある場合）

<img width="1744" height="303" alt="image" src="https://github.com/user-attachments/assets/0a5b60a4-299b-4be4-9e6a-ad1d2fda0692" />


## レビューしてほしい部分や不安な部分

- Server Actionsの実装が正しいか確認をお願いします。
---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
