### PR TITLE
[BE]記事一覧取得

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,14 @@
+import { PostCardSkeleton } from "@/components/PostCardSkeleton";
+import styles from "./styles.module.css";
+
+export default function Loading() {
+  return (
+    <main className={styles.main}>
+      <div className={styles.cardGrid}>
+        <PostCardSkeleton />
+        <PostCardSkeleton />
+        <PostCardSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,101 +1,32 @@
-"use client";
-
+import { createClient } from "@/libs/supabase/server";
 import { PostCard } from "@/components/PostCard";
 import { SearchForm } from "@/components/SearchForm";
 import styles from "./styles.module.css";
+import { searchAction } from "./actions";
 
-const dummyPosts = [
-  {
-    id: 1,
-    title: "1つ目の投稿",
-    author: "山田 太郎",
-    category: "Category",
-    thumbnailUrl: "/sample1.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 2,
-    title: "2つ目の投稿",
-    author: "鈴木 花子",
-    category: "Category",
-    thumbnailUrl: "/sample2.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 3,
-    title: "3つ目の投稿",
-    author: "高橋 健太",
-    category: "Category",
-    thumbnailUrl: "/sample3.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 4,
-    title: "4つ目の投稿",
-    author: "田中 美咲",
-    category: "Category",
-    thumbnailUrl: "/sample4.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 5,
-    title: "5つ目の投稿",
-    author: "伊藤 翔太",
-    category: "Category",
-    thumbnailUrl: "/sample5.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 6,
-    title: "6つ目の投稿",
-    author: "渡辺 彩",
-    category: "Category",
-    thumbnailUrl: "/sample1.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 7,
-    title: "7つ目の投稿",
-    author: "山本 大輔",
-    category: "Category",
-    thumbnailUrl: "/sample2.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-  {
-    id: 8,
-    title: "8つ目の投稿",
-    author: "中村 光",
-    category: "Category",
-    thumbnailUrl: "/sample3.jpg",
-    content: "てすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすとてすと",
-    createdAt: new Date(),
-  },
-];
+export default async function Home() {
+  const supabase = await createClient();
+  const { data: posts } = await supabase
+    .from("posts")
+    .select("*, users(name), categories(name)")
+    .order("created_at", { ascending: false });
 
-export default function Home() {
   return (
     <>
       <main className={styles.main}>
         <div className={styles.searchWrapper}>
-          <SearchForm onSearch={(value) => console.log(value)} />
+          <SearchForm searchAction={searchAction} />
         </div>
         <div className={styles.cardGrid}>
-          {dummyPosts.map((post) => (
+          {posts?.map((post) => (
             <PostCard
               key={post.id}
               title={post.title}
-              author={post.author}
-              category={post.category}
-              thumbnailUrl={post.thumbnailUrl}
+              author={post.users.name}
+              category={post.categories.name}
+              thumbnailUrl={post.image_path}
               content={post.content}
-              createdAt={post.createdAt}
+              createdAt={post.created_at}
             />
           ))}
         </div>


### PR DESCRIPTION
## 概要（何をしたPRか）

postsテーブルから記事データを全件取得し、ホーム画面に一覧表示する

## 関連Issue

Closes #39


## 変更内容

- `src/app/page.tsx`:
  - `"use client"` を削除し、Server Component に変更
    - Supabase の `@/libs/supabase/server` の `createClient` はサーバー専用のため
  - dummyPosts を削除し、Supabase の `posts` テーブルからデータ取得に変更
  - `SearchForm` の props を `onSearch` から `searchAction` に修正（[PR #44](https://github.com/if-mentor/next_teamdev_24_1/pull/44) の変更に合わせて）
- `src/app/loading.tsx`: データ取得中のスケルトン表示を追加（新規作成）
- `next.config.ts`: Supabase Storage の画像表示のため `*.supabase.co` ドメインを許可

## 影響範囲

- [x] UI
- [x] BE
- [x] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. ホーム画面（/）にアクセスするとpostsテーブルのデータがcreated_at降順で表示される
2. ページ読み込み中にスケルトンが表示される

## テストケース

- [x] postsテーブルのデータが一覧表示される
- [x] created_at降順で表示される
- [x] データ取得中にスケルトンが表示される
- [x] Supabase Storageの画像が表示される

## スクリーンショット（UI変更がある場合）

ローディング中の画面です
<img width="1419" height="695" alt="スクリーンショット 2026-05-02 22 23 34" src="https://github.com/user-attachments/assets/945a333f-c8d1-4880-8dcf-3ad78444c3c3" />
データ取得後の画面です
<img width="1423" height="692" alt="image" src="https://github.com/user-attachments/assets/25b97455-59c7-474b-9f02-308c2e1b967d" />


## レビューしてほしい部分や不安な部分

- [PR #44](https://github.com/if-mentor/next_teamdev_24_1/pull/44) で実装されていた UI レイアウト（SearchForm、cardGrid、styles）については、既存の構成をそのまま引き継ぐ形で対応しております。この進め方で問題ないか、ご確認いただけますと幸いです。
- Supabase Storage 上の画像を表示するため、next.config.ts に *.supabase.co のドメインを追加しております。こちらの設定方法で問題ないか、ご確認をお願いいたします。
- 今回は動作確認のため、手動で Supabase Storage に画像をアップロードし、image_path に URL を設定して表示確認を行っております。今後、画像投稿機能が実装された際には、そちらから自動的に image_path へ URL が保存される想定であるため、現時点ではこの対応で問題ないと考えておりますが、認識に相違がないか、ご確認いただけますと幸いです。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
