### PR TITLE
[BE]記事詳細取得

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,13 +1,39 @@
 import Image from "next/image";
+import { notFound } from "next/navigation";
+import { createClient } from "@/libs/supabase/server";
 import { CommentCard } from "@/components/CommentCard";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
 import styles from "./styles.module.css";
 import { dateConvert } from "@/utils/dateconvert";
-import { dummyArticle as article, dummyComments as comments } from "@/dummy/articleDetail";
+import { dummyComments as comments } from "@/dummy/articleDetail";
 import Link from "next/link";
 
-export default function ArticleDetailPage() {
+type ArticleDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function ArticleDetailPage({ params }: ArticleDetailPageProps) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: article, error } = await supabase
+    .from("posts")
+    .select(
+      `
+      id,
+      title,
+      content,
+      image_path,
+      created_at,
+      categories(name),
+      users(name, image_path)`,
+    )
+    .eq("id", Number(id))
+    .single();
+
+  if (error || !article) {
+    notFound();
+  }
   return (
     <>
       <main className={styles.main}>
@@ -15,10 +41,10 @@ export default function ArticleDetailPage() {
           <div className={styles.cardHeader}>
             <h1 className={styles.title}>{article.title}</h1>
             <div className={styles.authorWrapper}>
-              <span className={styles.authorLabel}>{article.author}</span>
+              <span className={styles.authorLabel}>{article.users.name}</span>
               <Image
-                src={article.authorAvatarUrl}
-                alt={article.author}
+                src={article.users.image_path || "/default_user_icon.png"}
+                alt={article.users.name}
                 width={32}
                 height={32}
                 className={styles.avatar}
@@ -26,20 +52,13 @@ export default function ArticleDetailPage() {
             </div>
           </div>
           <div className={styles.thumbnail}>
-            <Image
-              src={article.thumbnailUrl}
-              alt={article.title}
-              fill
-              sizes="720px"
-              className={styles.thumbnailImage}
-            />
+            <Image src={article.image_path} alt={article.title} fill sizes="720px" className={styles.thumbnailImage} />
           </div>
-          <span className={styles.category}>{article.category}</span>
+          <span className={styles.category}>{article.categories.name}</span>
           <p className={styles.content}>{article.content}</p>
           <div className={styles.footer}>
             <time className={styles.timestamp}>{dateConvert(article.created_at)}</time>
-            {/* バックエンド実装時に article.id に変更 */}
-            <Link href={`/articles/1/edit`}>
+            <Link href={`/articles/${article.id}/edit`}>
               <Button label="編集" variant="success" size="medium" />
             </Link>
           </div>


### PR DESCRIPTION
## 概要（何をしたPRか）
記事データの詳細をSuapabaseから取得する機能を追加しました。
<!-- 1〜2行でOK -->

## 関連Issue

Closes #48 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

-[id]のpage.tsx：現在はダミーの記事データが表示されるようになっているが、Supabaseから取り出した
記事データが表示されるように変更をした。コメントに関してはダミーのままである。

## 影響範囲

- [x] UI
- [x] BE
- [x] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. npm run devにて現在存在しないidでページを立ち上げ、404のエラーが正しく表れることを確かめた。

## テストケース
- [ ] 正常系の確認ができる
- [x] 異常系の確認ができる
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）
<img width="1736" height="800" alt="Screenshot 2026-05-03 005056" src="https://github.com/user-attachments/assets/93a6c274-cd9b-4e79-8459-f58527c7f1dd" />

<!-- 貼る -->

## レビューしてほしい部分や不安な部分

-import文が増えると、コードの上部の体裁が散らかっているように見えるのですが、実際の現場で使われているimportの並び順みたいなものがあれば教えていただきたいです。


---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
