### PR TITLE
[BE]認証制御

### DIFF
--- a/src/libs/supabase/middleware.ts
+++ b/src/libs/supabase/middleware.ts
@@ -1,0 +1,46 @@
+import type { Database } from "@/types/supabase";
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+// 未認証ならログインへ飛ばすパス (文字列は前方一致、正規表現は test で判定)
+const PROTECTED_PATHS: (string | RegExp)[] = ["/articles/new", "/profile", /^\/articles\/[^/]+\/edit$/];
+// 認証済みならホームへ飛ばすパス
+const GUEST_ONLY_PATHS = ["/login", "/signup"];
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+  const supabase = createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) => supabaseResponse.cookies.set(name, value, options));
+        },
+      },
+    },
+  );
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const { pathname } = request.nextUrl;
+  const isProtected = PROTECTED_PATHS.some((p) =>
+    typeof p === "string" ? pathname === p || pathname.startsWith(`${p}/`) : p.test(pathname),
+  );
+  const isGuestOnly = GUEST_ONLY_PATHS.some((p) => pathname === p);
+  if (!user && isProtected) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+  if (user && isGuestOnly) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+  return supabaseResponse;
+}

--- a/src/libs/supabase/middleware.ts
+++ b/src/libs/supabase/middleware.ts
@@ -32,15 +32,18 @@ export async function updateSession(request: NextRequest) {
     typeof p === "string" ? pathname === p || pathname.startsWith(`${p}/`) : p.test(pathname),
   );
   const isGuestOnly = GUEST_ONLY_PATHS.some((p) => pathname === p);
+
   if (!user && isProtected) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);
   }
+
   if (user && isGuestOnly) {
     const url = request.nextUrl.clone();
     url.pathname = "/";
     return NextResponse.redirect(url);
   }
+
   return supabaseResponse;
 }

--- a/src/libs/supabase/middleware.ts
+++ b/src/libs/supabase/middleware.ts
@@ -3,7 +3,7 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 // 未認証ならログインへ飛ばすパス (文字列は前方一致、正規表現は test で判定)
-const PROTECTED_PATHS: (string | RegExp)[] = ["/articles/new", "/profile", /^\/articles\/[^/]+\/edit$/];
+const PROTECTED_PATHS: (string | RegExp)[] = ["/articles/new", /^\/articles\/[^/]+\/edit$/];
 // 認証済みならホームへ飛ばすパス
 const GUEST_ONLY_PATHS = ["/login", "/signup"];
 export async function updateSession(request: NextRequest) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,8 @@
+import type { NextRequest } from "next/server";
+import { updateSession } from "@/libs/supabase/middleware";
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { updateSession } from "@/libs/supabase/middleware";
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 export const config = {


### PR DESCRIPTION
## 概要（何をしたPRか）

Next.js Middleware を用いた認証制御を実装。
- 未認証ユーザーが要保護ページにアクセスした際にログイン画面へリダイレクト
- 認証済みユーザーがゲスト専用ページにアクセスした際にホーム画面へリダイレクト


<!-- 1〜2行でOK -->

## 関連Issue

Closes #50 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容
```
src/
├── middleware.ts (新規)
└── libs/
　　　└── supabase/
　　　　　　└── middleware.ts (新規)
```
- `src/middleware.ts`: Next.js Middleware エントリ。静的アセットを除いた全リクエストで `updateSession` を実行
- `src/libs/supabase/middleware.ts`: Supabase セッション同期 + 認証状態に応じたリダイレクト制御
  - 未認証で要保護ページ → `/login`
  - 認証済でゲスト専用ページ → `/`

## 影響範囲

- [ ] UI
- [x] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法
1. `npm run dev` で開発サーバーを起動
2. **未認証状態** で以下にアクセス → すべて `/login` にリダイレクトされること
   - `http://localhost:3000/articles/new`
   - `http://localhost:3000/articles/1/edit`
   - `http://localhost:3000/profile`
3. **未認証状態** で `http://localhost:3000/articles/1` (詳細) にアクセス → リダイレクトされず閲覧可能なこと
4. ログイン後、**認証済み状態** で以下にアクセス → すべて `/` にリダイレクトされること
   - `http://localhost:3000/login`
   - `http://localhost:3000/signup`

## テストケース

- [x] 未認証で `/articles/new` → `/login` へリダイレクト
- [x] 未認証で `/articles/[id]/edit` → `/login` へリダイレクト
- [x] 未認証で `/profile` → `/login` へリダイレクト
- [x] 未認証で `/articles/[id]` (詳細) → 通常表示 (誤巻き込みなし)
- [x] 認証済みで `/login` → `/` へリダイレクト
- [x] 認証済みで `/signup` → `/` へリダイレクト
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）
UI変更なし。
<!-- 貼る -->

## レビューしてほしい部分や不安な部分
- #50 に記載のある`/profile` ページは未実装ですが、将来実装時の対応漏れを防ぐため Middleware の対象パスには含めています。問題なければそのままにする想定です
  - `/profile`不要との事なので、削除しました。
---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
