### PR TITLE
[FE]ImageUploaderPreviewにname属性を追加

### DIFF
--- a/src/components/ImageUploaderPreview/index.tsx
+++ b/src/components/ImageUploaderPreview/index.tsx
@@ -46,7 +46,14 @@ const ImageUploaderPreview = ({
   return (
     <div className={styles.wrapper}>
       <label className={`${styles.uploader} ${disabled ? styles.disabled : ""}`}>
-        <input type="file" accept={accept} disabled={disabled} onChange={processFile} className={styles.input} />
+        <input
+          type="file"
+          name="image"
+          accept={accept}
+          disabled={disabled}
+          onChange={processFile}
+          className={styles.input}
+        />
 
         {previewUrl ? (
           <Image src={previewUrl} alt="プレビュー" className={styles.previewImage} fill />


### PR DESCRIPTION
## 概要（何をしたPRか）
ImageUploaderPreviewのinputタグにname属性を追加した

## 関連Issue
Closes #65

## 変更内容
- ImageUploaderPreviewのinputタグに `name="image"` を追加

## 影響範囲
- [x] UI

## 動作確認方法
記事投稿画面で画像を選択し、form送信時にformDataから画像ファイルが取得できることを確認

## テストケース
- [x] 画像を選択できる
- [x] プレビューが表示される

## スクリーンショット（UI変更がある場合）
<!-- 見た目の変更はないため省略 -->

## レビューしてほしい部分や不安な部分
- name="image"の追加のみの変更です。

## 確認事項
- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）