### PR TITLE
[BE]コメント投稿

### DIFF
--- a/src/app/articles/[id]/CommentForm.tsx
+++ b/src/app/articles/[id]/CommentForm.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useActionState } from "react";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import { postComment } from "./action";
+import styles from "./styles.module.css";
+
+type Props = {
+  postId: number;
+};
+
+export function CommentForm({ postId }: Props) {
+  const [state, formAction] = useActionState(postComment, null);
+
+  return (
+    <form action={formAction} className={styles.commentForm}>
+      <Input placeholder="コメントを入力" name="content" size="large" />
+      <input type="hidden" name="post_id" value={postId} />
+      {state?.error && <p className={styles.errorMessage}>{state.error}</p>}
+      <Button label="コメント" variant="success" size="medium" type="submit" />
+    </form>
+  );
+}

--- a/src/app/articles/[id]/action.ts
+++ b/src/app/articles/[id]/action.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/libs/supabase/server";
+
+export async function postComment(
+  prevState: { error: string } | null,
+  formData: FormData,
+): Promise<{ error: string } | null> {
+  const content = formData.get("content") as string;
+  const postId = formData.get("post_id") as string;
+
+  if (!content || content.length < 1 || content.length > 80) {
+    return { error: "コメントは1文字以上80文字以内です" };
+  }
+
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { error } = await supabase.from("comments").insert({
+    content,
+    post_id: Number(postId),
+    user_id: user.id,
+  });
+
+  if (error) {
+    console.error("Supabaseエラー:", error);
+    return { error: "コメント投稿に失敗しました" };
+  }
+
+  revalidatePath(`/articles/${postId}`);
+  return null;
+}

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -2,11 +2,11 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { createClient } from "@/libs/supabase/server";
 import { CommentCard } from "@/components/CommentCard";
-import Input from "@/components/Input";
 import Button from "@/components/Button";
 import styles from "./styles.module.css";
 import { dateConvert } from "@/utils/dateconvert";
 import Link from "next/link";
+import { CommentForm } from "./CommentForm";
 
 type ArticleDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -81,10 +81,7 @@ export default async function ArticleDetailPage({ params }: ArticleDetailPagePro
 
         <section className={styles.commentSection}>
           <h2 className={styles.commentCount}>{comments?.length || 0}件のコメント</h2>
-          <form className={styles.commentInputWrapper}>
-            <Input placeholder="コメントを入力" size="large" />
-            <Button label="コメント" variant="success" size="medium" />
-          </form>
+          <CommentForm postId={article.id} />
           <div className={styles.commentList}>
             {comments?.map((comment) => (
               <CommentCard

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/Button";
 import styles from "./styles.module.css";
 import { dateConvert } from "@/utils/dateconvert";
 import Link from "next/link";
-import { CommentForm } from "./CommentForm";
+import { CommentForm } from "@/components/CommentForm";
 
 type ArticleDetailPageProps = {
   params: Promise<{ id: string }>;

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -107,3 +107,9 @@
   flex-direction: column;
   gap: 16px;
 }
+
+.errorMessage {
+  color: #e53e3e;
+  font-size: 12px;
+  margin: 0;
+}

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -94,22 +94,8 @@
   margin: 0 0 16px 0;
 }
 
-.commentInputWrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 12px;
-  margin-bottom: 24px;
-}
-
 .commentList {
   display: flex;
   flex-direction: column;
   gap: 16px;
-}
-
-.errorMessage {
-  color: #e53e3e;
-  font-size: 12px;
-  margin: 0;
 }

--- a/src/components/CommentForm/index.tsx
+++ b/src/components/CommentForm/index.tsx
@@ -3,14 +3,11 @@
 import { useActionState } from "react";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
-import { postComment } from "./action";
+import { postComment } from "../../app/articles/[id]/action";
 import styles from "./styles.module.css";
+import { CommentFormProps } from "./type";
 
-type Props = {
-  postId: number;
-};
-
-export function CommentForm({ postId }: Props) {
+export function CommentForm({ postId }: CommentFormProps) {
   const [state, formAction] = useActionState(postComment, null);
 
   return (

--- a/src/components/CommentForm/styles.module.css
+++ b/src/components/CommentForm/styles.module.css
@@ -1,0 +1,13 @@
+.commentForm {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.errorMessage {
+  color: #e53e3e;
+  font-size: 12px;
+  margin: 0;
+}

--- a/src/components/CommentForm/type.ts
+++ b/src/components/CommentForm/type.ts
@@ -1,0 +1,3 @@
+export type CommentFormProps = {
+  postId: number;
+};


### PR DESCRIPTION
## 概要（何をしたPRか）

コメント投稿機能を実装しました。Server ActionでSupabaseのcommentsテーブルにinsertされていることが確認済です。

## 関連Issue

Closes #59

## 変更内容

- `action.ts` 新規作成：コメント投稿のServer Action（バリデーション・auth連携）
- `CommentForm.tsx` 新規作成：コメントフォームのクライアントコンポーネント（useActionState でバリデーションエラーを画面表示）
- `page.tsx` 修正：フォーム部分を `CommentForm` コンポーネントに置き換え
- `styles.module.css` 修正：エラーメッセージのスタイル追加

## 影響範囲

- [x] UI
- [x] BE
- [x] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. ログインして記事詳細ページを開く
2. コメント欄にテキストを入力して「コメント」ボタンを押す

## テストケース

- [ ] ログインができる
- [x] バリデーションが発火する（空・81文字以上でエラーメッセージ表示）
- [x] 正常系の確認ができる（ログイン状態でコメント投稿→一覧に表示）
- [x] 異常系の確認ができる（未ログインでコメントボタン→ログインページへリダイレクト）

## スクリーンショット（UI変更がある場合）

<img width="771" height="414" alt="image" src="https://github.com/user-attachments/assets/dfba974b-a8fe-4208-8206-d640faa378cb" />

フォーム記入後、送信ボタンを押すとコメントとして表示されます。

<img width="1542" height="440" alt="image" src="https://github.com/user-attachments/assets/b96a3be9-5161-444e-a13c-bd832ade4872" />

フォームに未記入または80文字以上で送信ボタンを押すとエラーメッセージが表示されます

## レビューしてほしい部分や不安な部分

- 直近で認証機能が実装されたため、今回 `supabase.auth.getUser()` を使って動的なuser_idを登録するよう対応しました。この判断で大丈夫かご確認いただきたいです。

- useActionState を使うため、コメントフォームをクライアントコンポーネントとして分離した構成で問題ないか確認をお願いいたします。

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
