### PR TITLE
[FE]ImageUploaderPreviewコンポーネントに編集時の既存画像表示追加 

### DIFF
--- a/src/components/ImageUploaderPreview/index.tsx
+++ b/src/components/ImageUploaderPreview/index.tsx
@@ -17,7 +17,9 @@ const ImageUploaderPreview = ({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [internalError, setInternalError] = useState("");
 
-  const imageSrc = previewUrl || currentImagePath;
+  const safeImage =
+    previewUrl ||
+    (currentImagePath?.startsWith("http") ? currentImagePath : currentImagePath ? `/${currentImagePath}` : null);
 
   useEffect(() => {
     return () => {
@@ -58,8 +60,8 @@ const ImageUploaderPreview = ({
           className={styles.input}
         />
 
-        {imageSrc ? (
-          <Image src={imageSrc} alt="プレビュー" className={styles.previewImage} fill />
+        {safeImage ? (
+          <Image src={safeImage} alt="プレビュー" className={styles.previewImage} fill />
         ) : (
           <div className={styles.uploadButton}>画像アップロード</div>
         )}

--- a/src/components/ImageUploaderPreview/index.tsx
+++ b/src/components/ImageUploaderPreview/index.tsx
@@ -6,6 +6,7 @@ import styles from "./styles.module.css";
 import type { ImageUploaderPreviewProps } from "./type";
 
 const ImageUploaderPreview = ({
+  currentImagePath,
   accept = "image/png,image/jpeg,image/jpg",
   maxFileSizeMB = 5,
   disabled = false,
@@ -15,6 +16,8 @@ const ImageUploaderPreview = ({
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [internalError, setInternalError] = useState("");
+
+  const imageSrc = previewUrl || currentImagePath;
 
   useEffect(() => {
     return () => {
@@ -55,8 +58,8 @@ const ImageUploaderPreview = ({
           className={styles.input}
         />
 
-        {previewUrl ? (
-          <Image src={previewUrl} alt="プレビュー" className={styles.previewImage} fill />
+        {imageSrc ? (
+          <Image src={imageSrc} alt="プレビュー" className={styles.previewImage} fill />
         ) : (
           <div className={styles.uploadButton}>画像アップロード</div>
         )}

--- a/src/components/ImageUploaderPreview/type.ts
+++ b/src/components/ImageUploaderPreview/type.ts
@@ -3,4 +3,5 @@ export type ImageUploaderPreviewProps = {
   maxFileSizeMB?: number;
   disabled?: boolean;
   error?: string;
+  currentImagePath?: string | null;
 };


### PR DESCRIPTION
## 概要（何をしたPRか）
画像アップロード機能において、既存画像が表示されない問題を修正。

<!-- 1〜2行でOK -->

## 関連Issue

Closes #71

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

- ImageUploaderPreview コンポーネントに `currentImagePath` を追加
- 既存画像と新規画像のプレビュー切り替えを実装
- 画像パスを next/image で表示可能な形式に補正する処理を追加
- 相対パス形式の画像でも Invalid URL エラーが発生しないよう修正

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

※編集画面は別実装のため、レビュー時に以下を確認してください

1. 編集画面で既存画像が設定されている状態にする
2. ImageUploaderPreviewに既存画像が表示されることを確認する
3. 画像を変更した際にプレビューが正しく切り替わることを確認する

## テストケース

- [x] 既存画像が表示される
- [x] 画像変更時にプレビューが更新される

## スクリーンショット（UI変更がある場合）

<!-- 貼る -->

## レビューしてほしい部分や不安な部分

- 投稿画面でもこのコンポーネントが問題なく使える設計になっているかご確認をお願いします。
- 編集時のみ既存画像表示がされる実装になっているかご確認をお願いします。
- 画像パスの補正処理をコンポーネント内で行う方針で問題ないか

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
