### PR TITLE
[BE]記事更新

### DIFF
--- a/src/app/articles/[id]/edit/actions.ts
+++ b/src/app/articles/[id]/edit/actions.ts
@@ -32,11 +32,18 @@ export async function updateArticle(postId: number, formData: FormData) {
       error: "記事が見つからないか、編集権限がありません",
     };
   }
+  const { data: categories, error: categoryError } = await supabase.from("categories").select("id, name");
+
+  if (categoryError || !categories) {
+    return {
+      error: "カテゴリ取得に失敗しました",
+    };
+  }
 
   // フォームから値を取得
-  const categoryNames = ["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"];
   const categoryValue = formData.get("category_id") as string;
-  const category_id = categoryNames.indexOf(categoryValue) + 1;
+  const selectedCategory = categories.find((category) => category.name === categoryValue);
+  const category_id = selectedCategory?.id;
   const title = (formData.get("title") as string).trim();
   const content = (formData.get("content") as string).trim();
   const imageFile = formData.get("image") as File | null;
@@ -52,7 +59,7 @@ export async function updateArticle(postId: number, formData: FormData) {
     errors.content = "本文は10文字以上1000文字以内で入力してください";
   }
 
-  if (category_id === -1) {
+  if (!selectedCategory) {
     errors.category = "カテゴリを選択してください";
   }
 

--- a/src/app/articles/[id]/edit/actions.ts
+++ b/src/app/articles/[id]/edit/actions.ts
@@ -79,10 +79,7 @@ export async function updateArticle(postId: number, formData: FormData) {
     // 新しい画像を Supabase Storage にアップロード
     const ext = imageFile.name.split(".").pop();
     const filePath = `blog_image/posts/${crypto.randomUUID()}.${ext}`;
-    const { data: uploadData, error: uploadError } = await supabase.storage.from("teamdev").upload(filePath, imageFile);
-
-    console.log("uploadData:", uploadData);
-    console.log("uploadError:", uploadError);
+    const { error: uploadError } = await supabase.storage.from("teamdev").upload(filePath, imageFile);
 
     // 画像パスが存在しない場合
     if (uploadError) {
@@ -92,8 +89,6 @@ export async function updateArticle(postId: number, formData: FormData) {
     }
 
     const { data } = await supabase.storage.from("teamdev").getPublicUrl(filePath);
-
-    console.log("getPublicUrl data:", data);
 
     finalImagePath = data.publicUrl;
 

--- a/src/app/articles/[id]/edit/actions.ts
+++ b/src/app/articles/[id]/edit/actions.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { createClient } from "@/libs/supabase/server";
+import { revalidatePath } from "next/cache";
+
+export async function updateArticle(postId: number, formData: FormData) {
+  const supabase = await createClient();
+
+  // ログインユーザーの情報取得
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error("ログインしていません");
+  }
+
+  // 現在のデータを取得
+  const { data: existingPost, error: fetchError } = await supabase
+    .from("posts")
+    .select("*")
+    .eq("id", postId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (fetchError || !existingPost) {
+    throw new Error("記事が見つからないか、編集権限がありません");
+  }
+
+  // フォームから値を取得
+  const category_id = Number(formData.get("category_id"));
+  const title = (formData.get("title") as string).trim();
+  const content = (formData.get("content") as string).trim();
+  const imageFile = formData.get("image_path") as File | null;
+
+  // バリデーション
+  if (title.length < 1 || title.length > 40) {
+    throw new Error("タイトルは1文字以上40文字以内で入力してください");
+  }
+
+  if (content.length < 10 || content.length > 1000) {
+    throw new Error("記事詳細は10文字以上1000文字以内で入力してください");
+  }
+
+  if (!category_id) {
+    throw new Error("カテゴリを選択してください");
+  }
+
+  // 新しい画像を保存する画像パス（新しい画像がなければ既存画像を使用）
+  let finalImagePath = existingPost.image_path;
+  // 画像が選択されている場合のみアップロード
+  if (imageFile && imageFile.size > 0) {
+    const MAX_FILE_SIZE = 5 * 1024 * 1024;
+    if (imageFile.size > MAX_FILE_SIZE) {
+      throw new Error("画像サイズは5MB以下にしてください");
+    }
+
+    // 新しい画像を Supabase Storage にアップロード
+    const fileName = `${Date.now()}-${imageFile.name}`;
+    const { error: uploadError } = await supabase.storage.from("image_path").upload(fileName, imageFile);
+
+    // 画像パスが存在しない場合
+    if (uploadError) {
+      throw new Error("画像のアップロードに失敗しました");
+    }
+
+    finalImagePath = fileName;
+  }
+
+  if (!finalImagePath) {
+    throw new Error("画像は必須です");
+  }
+
+  // データを更新
+  const { error: updateError } = await supabase
+    .from(`posts`)
+    .update({
+      category_id,
+      title,
+      content,
+      image_path: finalImagePath,
+      updated_at: new Date().toISOString(),
+    })
+    .match({ id: postId, user_id: user.id });
+
+  // 更新失敗時
+  if (updateError) throw new Error(updateError.message);
+
+  revalidatePath(`/articles/${postId}`);
+}

--- a/src/app/articles/[id]/edit/actions.ts
+++ b/src/app/articles/[id]/edit/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/libs/supabase/server";
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
 export async function updateArticle(postId: number, formData: FormData) {
   const supabase = await createClient();
@@ -11,7 +12,11 @@ export async function updateArticle(postId: number, formData: FormData) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    throw new Error("ログインしていません");
+    return {
+      errors: {
+        title: "ログインしてください",
+      },
+    };
   }
 
   // 現在のデータを取得
@@ -23,56 +28,103 @@ export async function updateArticle(postId: number, formData: FormData) {
     .single();
 
   if (fetchError || !existingPost) {
-    throw new Error("記事が見つからないか、編集権限がありません");
+    return {
+      error: "記事が見つからないか、編集権限がありません",
+    };
   }
 
   // フォームから値を取得
-  const category_id = Number(formData.get("category_id"));
+  const categoryNames = ["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"];
+  const categoryValue = formData.get("category_id") as string;
+  const category_id = categoryNames.indexOf(categoryValue) + 1;
   const title = (formData.get("title") as string).trim();
   const content = (formData.get("content") as string).trim();
-  const imageFile = formData.get("image_path") as File | null;
+  const imageFile = formData.get("image") as File | null;
+
+  const errors: Record<string, string> = {};
+
+  console.log("DB user_id:", existingPost.user_id);
+  console.log("LOGIN user.id:", user.id);
+  console.log([...formData.entries()]);
+  console.log("postId:", postId);
+  console.log("typeof postId:", typeof postId);
 
   // バリデーション
   if (title.length < 1 || title.length > 40) {
-    throw new Error("タイトルは1文字以上40文字以内で入力してください");
+    errors.title = "タイトルは1〜40文字で入力してください";
   }
 
   if (content.length < 10 || content.length > 1000) {
-    throw new Error("記事詳細は10文字以上1000文字以内で入力してください");
+    errors.content = "本文は10文字以上1000文字以内で入力してください";
   }
 
-  if (!category_id) {
-    throw new Error("カテゴリを選択してください");
+  if (category_id === -1) {
+    errors.category = "カテゴリを選択してください";
   }
 
-  // 新しい画像を保存する画像パス（新しい画像がなければ既存画像を使用）
-  let finalImagePath = existingPost.image_path;
+  // まとめて返す
+  if (Object.keys(errors).length > 0) {
+    return { errors };
+  }
+
+  // 画像処理
+  let finalImagePath = existingPost.image_path; //新しい画像
+  let oldImagePathToDelete: string | null = null; //古い画像
+
   // 画像が選択されている場合のみアップロード
   if (imageFile && imageFile.size > 0) {
     const MAX_FILE_SIZE = 5 * 1024 * 1024;
     if (imageFile.size > MAX_FILE_SIZE) {
-      throw new Error("画像サイズは5MB以下にしてください");
+      return {
+        errors: {
+          image: "画像サイズは5MB以下にしてください",
+        },
+      };
     }
 
     // 新しい画像を Supabase Storage にアップロード
-    const fileName = `${Date.now()}-${imageFile.name}`;
-    const { error: uploadError } = await supabase.storage.from("image_path").upload(fileName, imageFile);
+    const ext = imageFile.name.split(".").pop();
+    const filePath = `blog_image/posts/${crypto.randomUUID()}.${ext}`;
+    const { data: uploadData, error: uploadError } = await supabase.storage.from("teamdev").upload(filePath, imageFile);
+
+    console.log("uploadData:", uploadData);
+    console.log("uploadError:", uploadError);
 
     // 画像パスが存在しない場合
     if (uploadError) {
-      throw new Error("画像のアップロードに失敗しました");
+      return {
+        error: "画像のアップロードに失敗しました",
+      };
     }
 
-    finalImagePath = fileName;
+    const { data } = await supabase.storage.from("teamdev").getPublicUrl(filePath);
+
+    console.log("getPublicUrl data:", data);
+
+    finalImagePath = data.publicUrl;
+
+    // 古い画像削除用（URL → path変換）
+    if (existingPost.image_path) {
+      oldImagePathToDelete = existingPost.image_path.split("/teamdev/")[1];
+    }
+
+    // const { data } = supabase.storage
+    //   .from("blog_image")
+    //   .getPublicUrl(fileName);
+
+    // finalImagePath = data.publicUrl;
+    // console.log("finalImagePath:", finalImagePath);
   }
 
   if (!finalImagePath) {
-    throw new Error("画像は必須です");
+    return {
+      error: "画像は必須です",
+    };
   }
 
   // データを更新
-  const { error: updateError } = await supabase
-    .from(`posts`)
+  const { data: updatedPost, error: updateError } = await supabase
+    .from("posts")
     .update({
       category_id,
       title,
@@ -80,10 +132,24 @@ export async function updateArticle(postId: number, formData: FormData) {
       image_path: finalImagePath,
       updated_at: new Date().toISOString(),
     })
-    .match({ id: postId, user_id: user.id });
+    .eq("id", postId)
+    .eq("user_id", user.id)
+    .select();
 
-  // 更新失敗時
-  if (updateError) throw new Error(updateError.message);
+  // 更新失敗時（0件更新も含めて判定）
+  if (updateError || !updatedPost || updatedPost.length === 0) {
+    return {
+      error: "データの更新に失敗しました",
+    };
+  }
+
+  // 古い画像の削除(DB更新が成功した後に実行）
+  if (oldImagePathToDelete) {
+    await supabase.storage.from("teamdev").remove([oldImagePathToDelete]);
+  }
 
   revalidatePath(`/articles/${postId}`);
+  revalidatePath("/");
+
+  redirect(`/articles/${postId}`);
 }

--- a/src/app/articles/[id]/edit/actions.ts
+++ b/src/app/articles/[id]/edit/actions.ts
@@ -43,12 +43,6 @@ export async function updateArticle(postId: number, formData: FormData) {
 
   const errors: Record<string, string> = {};
 
-  console.log("DB user_id:", existingPost.user_id);
-  console.log("LOGIN user.id:", user.id);
-  console.log([...formData.entries()]);
-  console.log("postId:", postId);
-  console.log("typeof postId:", typeof postId);
-
   // バリデーション
   if (title.length < 1 || title.length > 40) {
     errors.title = "タイトルは1〜40文字で入力してください";
@@ -107,13 +101,6 @@ export async function updateArticle(postId: number, formData: FormData) {
     if (existingPost.image_path) {
       oldImagePathToDelete = existingPost.image_path.split("/teamdev/")[1];
     }
-
-    // const { data } = supabase.storage
-    //   .from("blog_image")
-    //   .getPublicUrl(fileName);
-
-    // finalImagePath = data.publicUrl;
-    // console.log("finalImagePath:", finalImagePath);
   }
 
   if (!finalImagePath) {

--- a/src/app/articles/[id]/edit/editArticleForm.tsx
+++ b/src/app/articles/[id]/edit/editArticleForm.tsx
@@ -47,7 +47,7 @@ export default function ArticleEditForm({ postId, existingPost }: ArticleEditFor
       <main className={styles.content}>
         <div className={styles.titleField}>
           <Input name="title" defaultValue={existingPost.title} placeholder="タイトルを入力" type="text" size="large" />
-          {state?.errors?.title && <p className={styles.error}>{state.errors.title}</p>}
+          {state?.errors?.title && <p className={styles.errorMessage}>{state.errors.title}</p>}
         </div>
 
         <div className={styles.imageUploaderWrapper}>
@@ -63,12 +63,12 @@ export default function ArticleEditForm({ postId, existingPost }: ArticleEditFor
             defaultValue={defaultCategory}
             required
           />
-          {state?.errors?.category && <p className={styles.error}>{state.errors.category}</p>}
+          {state?.errors?.category && <p className={styles.errorMessage}>{state.errors.category}</p>}
         </div>
 
         <div className={styles.textBoxWrapper}>
           <TextBox name="content" defaultValue={existingPost.content} />
-          {state?.errors?.content && <p className={styles.error}>{state.errors.content}</p>}
+          {state?.errors?.content && <p className={styles.errorMessage}>{state.errors.content}</p>}
         </div>
 
         <div className={styles.buttonWrapper}>

--- a/src/app/articles/[id]/edit/editArticleForm.tsx
+++ b/src/app/articles/[id]/edit/editArticleForm.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useActionState } from "react";
+import { updateArticle } from "./actions";
+import Input from "@/components/Input";
+import SelectBox from "@/components/SelectBox";
+import Button from "@/components/Button";
+import ImageUploaderPreview from "@/components/ImageUploaderPreview";
+import TextBox from "@/components/TextBox";
+import styles from "./styles.module.css";
+
+const categoryNames = ["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"];
+
+type ArticleEditFormProps = {
+  postId: number;
+  existingPost: {
+    id: number;
+    title: string;
+    content: string;
+    image_path: string | null;
+    category_id: number;
+    user_id: string;
+  };
+};
+
+type ActionState = {
+  errors?: {
+    title?: string;
+    content?: string;
+    category?: string;
+    image?: string;
+  };
+  error?: string;
+} | null;
+
+export default function ArticleEditForm({ postId, existingPost }: ArticleEditFormProps) {
+  const [state, formAction] = useActionState<ActionState, FormData>(async (_prevState, formData: FormData) => {
+    return await updateArticle(postId, formData);
+  }, null);
+
+  const currentImageUrl = existingPost.image_path;
+
+  const defaultCategory = categoryNames[existingPost.category_id - 1] ?? "";
+
+  return (
+    <form action={formAction}>
+      <main className={styles.content}>
+        <div className={styles.titleField}>
+          <Input name="title" defaultValue={existingPost.title} placeholder="タイトルを入力" type="text" size="large" />
+          {state?.errors?.title && <p className={styles.error}>{state.errors.title}</p>}
+        </div>
+
+        <div className={styles.imageUploaderWrapper}>
+          <ImageUploaderPreview currentImagePath={currentImageUrl} error={state?.errors?.image} />
+        </div>
+
+        <div className={styles.selectBoxWrapper}>
+          <SelectBox
+            name="category_id"
+            label="カテゴリ"
+            options={categoryNames}
+            placeholder="カテゴリ選択"
+            defaultValue={defaultCategory}
+            required
+          />
+          {state?.errors?.category && <p className={styles.error}>{state.errors.category}</p>}
+        </div>
+
+        <div className={styles.textBoxWrapper}>
+          <TextBox name="content" defaultValue={existingPost.content} />
+          {state?.errors?.content && <p className={styles.error}>{state.errors.content}</p>}
+        </div>
+
+        <div className={styles.buttonWrapper}>
+          <Button type="submit" label="更新" variant="success" />
+          <Button type="submit" label="削除" variant="danger" />
+        </div>
+      </main>
+    </form>
+  );
+}

--- a/src/app/articles/[id]/edit/editArticleForm.tsx
+++ b/src/app/articles/[id]/edit/editArticleForm.tsx
@@ -9,8 +9,6 @@ import ImageUploaderPreview from "@/components/ImageUploaderPreview";
 import TextBox from "@/components/TextBox";
 import styles from "./styles.module.css";
 
-const categoryNames = ["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"];
-
 type ArticleEditFormProps = {
   postId: number;
   existingPost: {
@@ -21,6 +19,10 @@ type ArticleEditFormProps = {
     category_id: number;
     user_id: string;
   };
+  categories: {
+    id: number;
+    name: string;
+  }[];
 };
 
 type ActionState = {
@@ -33,14 +35,16 @@ type ActionState = {
   error?: string;
 } | null;
 
-export default function ArticleEditForm({ postId, existingPost }: ArticleEditFormProps) {
+export default function ArticleEditForm({ postId, existingPost, categories }: ArticleEditFormProps) {
   const [state, formAction] = useActionState<ActionState, FormData>(async (_prevState, formData: FormData) => {
     return await updateArticle(postId, formData);
   }, null);
 
   const currentImageUrl = existingPost.image_path;
 
-  const defaultCategory = categoryNames[existingPost.category_id - 1] ?? "";
+  const categoryNames = categories.map((category) => category.name);
+
+  const defaultCategory = categories.find((category) => category.id === existingPost.category_id)?.name ?? "";
 
   return (
     <form action={formAction}>

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -4,32 +4,38 @@ import SelectBox from "@/components/SelectBox";
 import Button from "@/components/Button";
 import ImageUploaderPreview from "@/components/ImageUploaderPreview";
 import TextBox from "@/components/TextBox";
+import { updateArticle } from "./actions";
 
-export default function ArticleEditPage() {
+export default async function ArticleEditPage({ params }: { params: { id: string } }) {
+  const postId = Number(params.id);
+
   return (
     <>
-      <main className={styles.content}>
-        <div className={styles.titleField}>
-          <Input placeholder="タイトルを入力" type="text" size="large" />
-        </div>
-        <div className={styles.imageUploaderWrapper}>
-          <ImageUploaderPreview />
-        </div>
-        <div className={styles.selectBoxWrapper}>
-          <SelectBox
-            label="カテゴリ"
-            options={["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"]}
-            placeholder="カテゴリ選択"
-          />
-        </div>
-        <div className={styles.textBoxWrapper}>
-          <TextBox />
-        </div>
-        <div className={styles.buttonWrapper}>
-          <Button label="更新" variant="success" />
-          <Button label="削除" variant="danger" />
-        </div>
-      </main>
+      <form action={updateArticle.bind(null, postId)} method="post">
+        <main className={styles.content}>
+          <div className={styles.titleField}>
+            <Input name="title" placeholder="タイトルを入力" type="text" size="large" />
+          </div>
+          <div className={styles.imageUploaderWrapper}>
+            <ImageUploaderPreview />
+          </div>
+          <div className={styles.selectBoxWrapper}>
+            <SelectBox
+              name="category_id"
+              label="カテゴリ"
+              options={["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"]}
+              placeholder="カテゴリ選択"
+            />
+          </div>
+          <div className={styles.textBoxWrapper}>
+            <TextBox name="content" />
+          </div>
+          <div className={styles.buttonWrapper}>
+            <Button type="submit" label="更新" variant="success" />
+            <Button label="削除" variant="danger" />
+          </div>
+        </main>
+      </form>
     </>
   );
 }

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -1,41 +1,33 @@
-import Input from "@/components/Input";
-import styles from "./styles.module.css";
-import SelectBox from "@/components/SelectBox";
-import Button from "@/components/Button";
-import ImageUploaderPreview from "@/components/ImageUploaderPreview";
-import TextBox from "@/components/TextBox";
-import { updateArticle } from "./actions";
+import ArticleEditForm from "./editArticleForm";
+import { createClient } from "@/libs/supabase/server";
 
-export default async function ArticleEditPage({ params }: { params: { id: string } }) {
-  const postId = Number(params.id);
+type PageProps = {
+  params: {
+    id: string;
+  };
+};
 
-  return (
-    <>
-      <form action={updateArticle.bind(null, postId)} method="post">
-        <main className={styles.content}>
-          <div className={styles.titleField}>
-            <Input name="title" placeholder="タイトルを入力" type="text" size="large" />
-          </div>
-          <div className={styles.imageUploaderWrapper}>
-            <ImageUploaderPreview />
-          </div>
-          <div className={styles.selectBoxWrapper}>
-            <SelectBox
-              name="category_id"
-              label="カテゴリ"
-              options={["日常", "仕事", "勉強", "美容", "趣味", "購入品", "健康", "その他"]}
-              placeholder="カテゴリ選択"
-            />
-          </div>
-          <div className={styles.textBoxWrapper}>
-            <TextBox name="content" />
-          </div>
-          <div className={styles.buttonWrapper}>
-            <Button type="submit" label="更新" variant="success" />
-            <Button label="削除" variant="danger" />
-          </div>
-        </main>
-      </form>
-    </>
-  );
+export default async function ArticleEditPage({ params }: PageProps) {
+  const { id } = await params;
+  const postId = Number(id);
+  const supabase = await createClient();
+
+  // 現在のログインユーザーを取得
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 投稿データを取得
+  const { data: existingPost, error } = await supabase.from("posts").select("*").eq("id", postId).single();
+
+  if (error || !existingPost) {
+    return <p>投稿が見つかりません。</p>;
+  }
+
+  // 所有者チェック
+  if (!user || existingPost.user_id !== user.id) {
+    return <p>投稿者以外は編集できません。</p>;
+  }
+
+  return <ArticleEditForm postId={postId} existingPost={existingPost} />;
 }

--- a/src/app/articles/[id]/edit/page.tsx
+++ b/src/app/articles/[id]/edit/page.tsx
@@ -20,8 +20,14 @@ export default async function ArticleEditPage({ params }: PageProps) {
   // 投稿データを取得
   const { data: existingPost, error } = await supabase.from("posts").select("*").eq("id", postId).single();
 
+  const { data: categories, error: categoryError } = await supabase.from("categories").select("id, name");
+
   if (error || !existingPost) {
     return <p>投稿が見つかりません。</p>;
+  }
+
+  if (categoryError || !categories) {
+    return <p>カテゴリ取得に失敗しました。</p>;
   }
 
   // 所有者チェック
@@ -29,5 +35,5 @@ export default async function ArticleEditPage({ params }: PageProps) {
     return <p>投稿者以外は編集できません。</p>;
   }
 
-  return <ArticleEditForm postId={postId} existingPost={existingPost} />;
+  return <ArticleEditForm postId={postId} existingPost={existingPost} categories={categories} />;
 }

--- a/src/app/articles/[id]/edit/styles.module.css
+++ b/src/app/articles/[id]/edit/styles.module.css
@@ -34,3 +34,9 @@
   width: 100%;
   justify-content: flex-end;
 }
+
+.errorMessage {
+  color: #dc2626;
+  font-size: 14px;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## 概要（何をしたPRか）
記事編集画面から記事データを更新できるようにし、formAction（Server Actions）を用いて更新処理を実装した。

<!-- 1〜2行でOK -->

## 関連Issue

Closes #56

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

- 記事編集による更新処理を実装
- 更新対象項目（category_id, title, content, image_path, updated_at）を追加
- 作成者本人のみ更新できるよう制御を追加
- バリデーション処理を追加

## 影響範囲

- [x] UI
- [x] BE
- [x] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

※ ImageUploaderPreview コンポーネントの修正内容（PR #72）を取り込んだ状態でご確認をお願いします。

1. ログインする
2. 自分が作成した記事の編集画面を開く
3. title / category / content / image を変更する
4. 更新ボタンを押下し、正常に保存されることを確認する
5. 更新後、記事詳細画面に変更内容が反映されることを確認する
6. 他ユーザーの記事は編集できないことを確認する

## テストケース

- [x] 記事が編集・更新できる
- [x] バリデーションが正しく動作する
- [x] 画像アップロードができる（5MB制限）
- [x] 作成者のみ編集できる
- [x] 更新内容が反映される

## スクリーンショット（UI変更がある場合）

<!-- 貼る -->

## レビューしてほしい部分や不安な部分

- ImageUploaderPreviewコンポーネントの設計について別Issueで議論中のため、今回の実装がその方針とズレていないか確認をお願いします。
- formAction（Server Actions）を使った更新処理の実装方針が適切か（クライアントとの責務分離・バリデーションの位置含めて）ご確認お願いします。

---

## 確認事項

- [x] 作業ブランチで git pull origin main を実行した
- [x] コンフリクトがあればローカルで解決した）
