### PR TITLE
[FIX]SelectBoxにvalue属性を追加

### DIFF
--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -7,11 +7,17 @@ const SelectBox = ({ label, options, placeholder, ...selectProps }: SelectProps)
       <label className={styles.label}>{label}</label>
       <select className={styles.select} {...selectProps}>
         <option value="">{placeholder}</option>
-        {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
+        {options.map((option) =>
+          typeof option === "string" ? (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ) : (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ),
+        )}
       </select>
     </>
   );

--- a/src/components/SelectBox/type.ts
+++ b/src/components/SelectBox/type.ts
@@ -1,7 +1,12 @@
 import { SelectHTMLAttributes } from "react";
 
+export type SelectOption = {
+  label: string; // ← 選択肢の表示テキスト（例：「日常」「仕事」）
+  value: string; // ← 実際に送信される値（例：「6」「7」）
+};
+
 export type SelectProps = {
-  label?: string;
-  options: string[];
+  label?: string; // ← SelectBoxの上に表示するラベル（例：「カテゴリ」）
+  options: string[] | SelectOption[];
   placeholder?: string;
 } & SelectHTMLAttributes<HTMLSelectElement>;


### PR DESCRIPTION
## 概要（何をしたPRか）
SelectBoxコンポーネントにvalue属性を追加した

## 関連Issue
Closes #74

## 変更内容
- SelectBox/type.tsにSelectOption型を追加
- SelectBox/index.tsxのoptionsを文字列配列と{ label, value }配列の両方に対応

## 影響範囲
- [x] UI

## 動作確認方法
```tsx
// 文字列配列（既存の使い方）
<SelectBox options={["日常", "仕事"]} placeholder="選択してください" />

// オブジェクト配列（新しい使い方）
<SelectBox
  options={[
    { label: "日常", value: "6" },
    { label: "仕事", value: "7" },
  ]}
  placeholder="選択してください"
/>
```
## レビューしてほしい部分や不安な部分
- SelectOptionと SelectPropsで同じ名称"label"を使用していますが、別の名称に変えた方がよいでしょうか。
- 既存のコードに影響がないよう「文字列」とオブジェクト、どちらの形式で渡されても対応できるようにしています。
- 動作確認は投稿画面にて実行します。

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
