### PR TITLE
ページネーションコンポーネント

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,44 @@
 import { createClient } from "@/libs/supabase/server";
 import { PostCard } from "@/components/PostCard";
 import { SearchForm } from "@/components/SearchForm";
+import { Pagination } from "@/components/Pagination";
 import styles from "./styles.module.css";
 import { searchAction } from "./actions";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
-export default async function Home() {
+const PAGE_SIZE = 8;
+
+type HomeProps = {
+  searchParams: Promise<{ page?: string }>;
+};
+
+export default async function Home({ searchParams }: HomeProps) {
+  const { page } = await searchParams;
+  const pageNumber = Number(page);
+  const isValidPage = Number.isInteger(pageNumber) && pageNumber >= 1;
+
+  if (page !== undefined && !isValidPage) {
+    redirect("/");
+  }
+
+  const currentPage = isValidPage ? pageNumber : 1;
+  const startIndex = (currentPage - 1) * PAGE_SIZE;
+  const endIndex = startIndex + PAGE_SIZE - 1;
+
   const supabase = await createClient();
-  const { data: posts } = await supabase
+
+  const { data: posts, count } = await supabase
     .from("posts")
-    .select("*, users(name), categories(name)")
-    .order("created_at", { ascending: false });
+    .select("*, users(name), categories(name)", { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range(startIndex, endIndex);
+
+  const totalPages = Math.ceil((count ?? 0) / PAGE_SIZE);
+
+  if (currentPage > Math.max(totalPages, 1)) {
+    redirect("/");
+  }
 
   return (
     <>
@@ -32,6 +60,7 @@ export default async function Home() {
             </Link>
           ))}
         </div>
+        <Pagination currentPage={currentPage} totalPages={totalPages} />
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { SearchForm } from "@/components/SearchForm";
 import { Pagination } from "@/components/Pagination";
 import styles from "./styles.module.css";
 import { searchAction } from "./actions";
+import { getValidPageNumber } from "@/utils/getValidPageNumber";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -15,14 +16,9 @@ type HomeProps = {
 
 export default async function Home({ searchParams }: HomeProps) {
   const { page } = await searchParams;
-  const pageNumber = Number(page);
-  const isValidPage = Number.isInteger(pageNumber) && pageNumber >= 1;
-
-  if (page !== undefined && !isValidPage) {
-    redirect("/");
-  }
-
-  const currentPage = isValidPage ? pageNumber : 1;
+  const parsedPage = getValidPageNumber(page);
+  if (parsedPage === null) redirect("/");
+  const currentPage = parsedPage;
   const startIndex = (currentPage - 1) * PAGE_SIZE;
   const endIndex = startIndex + PAGE_SIZE - 1;
 

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import styles from "./styles.module.css";
+import { PaginationProps } from "./type";
+
+export function Pagination({ currentPage, totalPages }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className={styles.pagination}>
+      {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+        <Link
+          key={page}
+          href={`/?page=${page}`}
+          className={`${styles.pageButton} ${currentPage === page ? styles.active : ""}`}
+        >
+          {page}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Pagination/styles.module.css
+++ b/src/components/Pagination/styles.module.css
@@ -1,0 +1,27 @@
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 32px;
+}
+
+.pageButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid #333;
+  border-radius: 50%;
+  font-size: 14px;
+  color: #333;
+  text-decoration: none;
+  background-color: #ffffff;
+}
+
+.active {
+  background-color: #000000;
+  border-color: #000000;
+  color: #ffffff;
+  font-weight: bold;
+}

--- a/src/components/Pagination/type.ts
+++ b/src/components/Pagination/type.ts
@@ -1,0 +1,4 @@
+export type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+};

--- a/src/utils/getValidPageNumber.ts
+++ b/src/utils/getValidPageNumber.ts
@@ -1,0 +1,5 @@
+export function getValidPageNumber(page: string | undefined): number | null {
+  if (page === undefined) return 1;
+  const n = Number(page);
+  return Number.isInteger(n) && n >= 1 ? n : null;
+}

--- a/src/utils/getValidPageNumber.ts
+++ b/src/utils/getValidPageNumber.ts
@@ -1,5 +1,5 @@
 export function getValidPageNumber(page: string | undefined): number | null {
   if (page === undefined) return 1;
-  const n = Number(page);
-  return Number.isInteger(n) && n >= 1 ? n : null;
+  if (!/^[1-9]\d*$/.test(page)) return null;
+  return Number(page);
 }


### PR DESCRIPTION
## 概要（何をしたPRか）


ページネーションコンポーネントを実装し、記事一覧ページに1ページ8件表示のページネーション機能を追加しました。

## 関連Issue

Closes #61



## 変更内容

- `Pagination` コンポーネントを新規作成（index.tsx / styles.module.css / type.ts）
- `page.tsx` に `?page=` を使ったページ切り替え処理を追加
- 1ページに表示する投稿数を8件に指定
- ページ番号が正しい数字か確認する処理を `getValidPageNumber` に作成
- 不正なページ番号（マイナス・小数・文字列など）はトップページにリダイレクト
- 存在しないページ番号（totalPagesを超える値）もトップページにリダイレクト


## 影響範囲

- [x] UI
- [x] BE
- [x] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `npm run dev` でローカル起動
2. `http://localhost:3000/` で記事一覧ページを開く

## テストケース

- [x] 1ページ目には投稿が最大8件表示される
- [x] ページ番号「2」をクリックすると、2ページ目の投稿に切り替わる
- [x] 不正なページ番号（例：`/?page=-2`、`/?page=abc`、`/?page=1.5`）をURLに入力すると、トップページに戻る
- [x] 存在しないページ番号（例：`/?page=99`）をURLに入力すると、トップページに戻る
- [x] 投稿が8件以下の場合は、ページネーションが表示されない

## スクリーンショット（UI変更がある場合）


<img width="2284" height="358" alt="image" src="https://github.com/user-attachments/assets/4beb151a-4030-41ae-bb31-1b4bedb5d59c" />


## レビューしてほしい部分や不安な部分

- ページネーション全体の実装方針（`?page=` クエリパラメータ・Supabase の `.range()` を使った方法）が適切かご確認いただきたいです。
- `PAGE_SIZE` は、現在のUIが4列表示のため、4列 × 2行になるように8件に設定しています。この表示件数で問題ないか確認いただきたいです。
- 現在は `totalPages` の数だけページ番号をすべて表示しています。投稿数が増えた場合、ページ番号が大量に表示される懸念があるため、今後は省略表示（例：`1 2 3 4 5 ... 15`）にする必要があるか確認いただきたいです。
- `getValidPageNumber` のバリデーション方針（`Number.isInteger` で整数チェック・`null` を返して呼び出し元で `redirect`）が適切かご確認いただきたいです。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
