### PR TITLE
[BE]記事検索

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -10,5 +10,9 @@ export async function logout() {
 }
 
 export async function searchAction(formData: FormData) {
-  console.log(formData.get("keyword"));
+  const keyword = formData.get("keyword")?.toString().trim() ?? "";
+  if (keyword === "") {
+    redirect("/");
+  }
+  redirect(`/?keyword=${encodeURIComponent(keyword)}`);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,12 +5,18 @@ import styles from "./styles.module.css";
 import { searchAction } from "./actions";
 import Link from "next/link";
 
-export default async function Home() {
+export default async function Home({ searchParams }: { searchParams: Promise<{ keyword?: string }> }) {
+  const { keyword } = await searchParams;
   const supabase = await createClient();
-  const { data: posts } = await supabase
+  let query = supabase
     .from("posts")
     .select("*, users(name), categories(name)")
     .order("created_at", { ascending: false });
+  if (keyword) {
+    query = query.ilike("title", `%${keyword}%`);
+  }
+
+  const { data: posts } = await query;
 
   return (
     <>

--- a/src/components/SearchForm/index.tsx
+++ b/src/components/SearchForm/index.tsx
@@ -24,7 +24,7 @@ export const SearchForm = ({
           disabled={disabled}
           className={styles.searchInput}
         />
-        <Button label="検索" disabled={disabled} />
+        <Button label="検索" type="submit" disabled={disabled} />
       </div>
     </form>
   );


### PR DESCRIPTION
## 概要（何をしたPRか）

<!-- 1〜2行でOK -->
Home画面のサーチボックスから、記事タイトルにキーワードを含むものを部分一致で検索できるように実装。

- サーチボックスにキーワードを入力 → Enter または「検索」ボタンで送信
- URLクエリ（`/?keyword=xxx`）として検索状態を保持し、Server側で絞り込み

## 関連Issue

Closes #60 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容
```
src/
├── app/
│   ├── actions.ts (修正)
│   └── page.tsx (修正)
└── components/
     └── SearchForm/
          └── index.tsx (修正)
```
- `src/app/actions.ts`: `searchAction` を実装。`formData` から `keyword` を取得し、空なら `/` へ、値があれば `/?keyword=...` へ `redirect`
- `src/app/page.tsx`: `searchParams` から `keyword` を受け取り、Supabase の `ilike("title", \`%${keyword}%\`)` でタイトル部分一致検索（大文字小文字を無視）
- `src/components/SearchForm/index.tsx`: 検索ボタンを `type="submit"` 指定。クリック・Enter どちらでも送信できるように

## 影響範囲

- [ ] UI
- [x] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `npm run dev` で開発サーバーを起動
2. `http://localhost:3000` にアクセス
3. サーチボックスに既存記事のタイトル一部を入力 → Enter
   - URL が `/?keyword=xxx` に変わり、該当記事のみ表示されること
4. 「検索」ボタンクリックでも同じ挙動になること
5. 空のまま送信 → `/` に戻り全件表示されること
6. 大文字小文字を混ぜたキーワード → 両方ヒットすること

## テストケース

- [x] 既存記事のタイトル一部で検索 → 該当記事のみ表示
- [x] 大文字小文字混在のキーワード → `ilike` により両方ヒット
- [x] 存在しないキーワード → 0件表示
- [x] 空文字で検索 → 全件表示にリセット
- [x] 検索ボタンクリック・Enter どちらでも検索が走る
<!-- 実装内容に応じて追加してください -->

## スクリーンショット（UI変更がある場合）
UI変更なし。
<!-- 貼る -->

## レビューしてほしい部分や不安な部分

 - 検索ボタンで送信後にキャレットが入力欄の左上にずれてしまう。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
